### PR TITLE
Installfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stretch-20170907
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y apt-utils \
@@ -23,13 +25,9 @@ RUN apt-get update && \
                        crunch \
                        cewl \
                        sonic-visualiser \
-                       atomicparsley
-
-RUN pip3 install python-magic
-
-RUN pip install tqdm
-
-ENV DEBIAN_FRONTEND noninteractive
+                       atomicparsley && \
+    pip3 install python-magic && \
+    pip install tqdm
 
 COPY install /tmp/install
 RUN chmod a+x /tmp/install/*.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,9 @@ RUN pip install tqdm
 ENV DEBIAN_FRONTEND noninteractive
 
 COPY install /tmp/install
-RUN find /tmp/install -name '*.sh' -exec chmod a+x {} + && \
-    find /tmp/install -type f -executable -exec {} \; && \
+RUN chmod a+x /tmp/install/*.sh && \
+    for i in /tmp/install/*.sh;do echo $i && $i;done && \
     rm -rf /tmp/install
-
 
 # Use this section to try new installation scripts.
 # All previous steps will be cached


### PR DESCRIPTION
The original Dockerfile used `find`, which silently failed.
To see the error, search for 'ead98e704451' in the [Dockerhub buildlog](https://hub.docker.com/r/dominicbreuker/stego-toolkit/builds/b35fdwbietjiv3d9z8eu7ez/).
This error prevented a couple of tools from being installed.
You can verify this by pulling the latest from docker hub and verify that some install scripts have not been executed.

From the build log:
```shell
Step 7/11 : RUN find /tmp/install -name '*.sh' -exec chmod a+x {} + &&     find /tmp/install -type f -executable -exec {} \; &&     rm -rf /tmp/install

 ---> Running in ead98e704451

[91mfind: '/tmp/install/openpuff.sh': Text file busy
find: '/tmp/install/jphide.sh': Text file busy
find: '/tmp/install/mp3stego.sh': Text file busy
find: '/tmp/install/stegsolve.sh': Text file busy
find: '/tmp/install/steganabara.sh': Text file busy
find: '/tmp/install/LSBSteg.sh': Text file busy
find: '/tmp/install/cloaked_pixel.sh': Text file busy
find: '/tmp/install/spectrology.sh': Text file busy
find: '/tmp/install/hideme.sh': Text file busy
```

I've also reduced the build layers with the second commit.
