### PR TITLE
Update Notepad++ download URLs to current versions

### DIFF
--- a/install/wine.sh
+++ b/install/wine.sh
@@ -30,8 +30,8 @@ apt-get install -y \
 WINEARCH=win32 WINEPREFIX=/root/.wine winecfg
 
 # Download and install notepad++ (32 bit / 64 bit) for testing
-wget -O /tmp/notepad32.7z https://notepad-plus-plus.org/repository/7.x/7.5.1/npp.7.5.1.bin.7z
-wget -O /tmp/notepad64.7z https://notepad-plus-plus.org/repository/7.x/7.5.1/npp.7.5.1.bin.x64.7z
+wget -O /tmp/notepad32.7z https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.9/npp.7.9.portable.7z
+wget -O /tmp/notepad64.7z https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.9/npp.7.9.portable.x64.7z
 7z e -o/opt/notepad32 -y /tmp/notepad32.7z
 7z e -o/opt/notepad64 -y /tmp/notepad64.7z
 rm /tmp/notepad32.7z


### PR DESCRIPTION
Fixed #18 by replacing the old Notepad++ URLs on notepad-plus-plus.org with links to download the current version from Github. The [Notepad++ website's release page](https://notepad-plus-plus.org/downloads/v7.9/) now also uses links to Github instead of same-domain links, so they seem to be canonical.