### PR TITLE
README.md wrong argument sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It will have the `data` folder mounted, into which you can put the files to anal
 
 If you don't use the scripts, follow these steps:
 1. Build image (`docker build -t <image_name> .`) or pull from Docker hub (`docker pull dominicbreuker/stego-toolkit`)
-2. Start a container with your files mounted to the folder `/data` (`docker run -it <image_name> -v /local/folder/with/data:/data /bin/bash`)
+2. Start a container with your files mounted to the folder `/data` (`docker run -v /local/folder/with/data:/data -it <image_name> /bin/bash`)
 3. Use CLI tools and screening scripts on your files: e.g., run `check_jpg.sh image.jpg` to create a quick report, or run `brute_jpg.sh image.jpg wordlist.txt` to try extracting hidden data with various tools and passwords
 4. If you want to run GUI tools use one of these two ways:
   - Run `start_ssh.sh` and connect to your container with X11 forwarding


### PR DESCRIPTION
The current argument sequence creates an error using docker:

docker run -it dominicbreuker/stego-toolkit -v /local/folder/with/data:/data /bin/bash
docker: Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: exec: "-v": executable file not found in $PATH: unknown.
ERRO[0000] error waiting for container: context canceled

The right sequence is:

docker run -v /local/folder/with/data:/data -it <image_name> /bin/bash