### PR TITLE
Updated Stegano version

### DIFF
--- a/install/stegano.sh
+++ b/install/stegano.sh
@@ -5,7 +5,7 @@ set -e
 # Download
 git clone https://github.com/cedricbonhomme/Stegano.git /opt/Stegano
 cd /opt/Stegano
-git checkout v0.8.2
+git checkout v0.11.1
 
 # Install
 pip3 install -r /opt/Stegano/requirements.txt


### PR DESCRIPTION
The `v0.8.2` version of Stegano that was used previously occasionally gave the following error:

```log
# stegano-lsb reveal -i specimen-image.png -e UTF-8 -o output.txt
Traceback (most recent call last):
File "/opt/Stegano/stegano-lsb", line 94, in <module>
data = tools.base642binary(secret)
File "/opt/Stegano/stegano/tools.py", line 100, in base642binary
b64_fname += '==='
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```

This upgrade will resolve the problems I was encountering.