### PR TITLE
Modernize stego-toolkit for 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,109 @@
+name: CI - Build and Test
+
+on:
+  push:
+    branches: [master, main, 'modernization/*']
+  pull_request:
+    branches: [master, main]
+
+env:
+  IMAGE_NAME: stego-toolkit
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run smoke tests
+        run: |
+          chmod +x ./tests/smoke_test.sh
+          ./tests/smoke_test.sh ${{ env.IMAGE_NAME }}:test
+
+      - name: Push Docker image
+        if: github.event_name != 'pull_request' && success()
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  lint-scripts:
+    name: Lint Shell Scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Lint shell scripts
+        run: |
+          find scripts/ -name '*.sh' -type f | xargs shellcheck --severity=warning || true
+          find bin/ -name '*.sh' -type f | xargs shellcheck --severity=warning || true
+
+  lint-python:
+    name: Lint Python Scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install linters
+        run: pip install flake8 black
+
+      - name: Run flake8
+        run: flake8 scripts/*.py --max-line-length=120 --ignore=E501 || true
+
+      - name: Check formatting with black
+        run: black --check --diff scripts/*.py || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,179 @@
-FROM debian:stretch-20170907
+# =============================================================================
+# Stego-Toolkit: Modern Steganography CTF Toolkit
+# 2025 Refresh - Modernized Docker Image
+# =============================================================================
+FROM debian:bookworm-slim
 
-ENV DEBIAN_FRONTEND noninteractive
+# Image metadata
+LABEL org.opencontainers.image.title="Stego-Toolkit"
+LABEL org.opencontainers.image.description="Dockerized collection of steganography tools for CTF challenges"
+LABEL org.opencontainers.image.version="2.0.0"
+LABEL org.opencontainers.image.authors="DominicBreuker (original), consigcody94 (2025 refresh)"
+LABEL org.opencontainers.image.source="https://github.com/consigcody94/stego-toolkit"
+LABEL org.opencontainers.image.licenses="MIT"
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y apt-utils \
-                       forensics-all \
-                       foremost \
-                       binwalk \
-                       exiftool \
-                       outguess \
-                       pngtools \
-                       pngcheck \
-                       stegosuite \
-                       git \
-                       hexedit \
-                       python3-pip \
-                       python-pip \
-                       autotools-dev \
-                       automake \
-                       libevent-dev \
-                       bsdmainutils \
-                       ffmpeg \
-                       crunch \
-                       cewl \
-                       sonic-visualiser \
-                       xxd \
-                       atomicparsley && \
-    pip3 install python-magic && \
-    pip install tqdm
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
 
+# Set locale for consistent behavior
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# =============================================================================
+# Stage 1: Install system packages
+# =============================================================================
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+    # Core utilities
+    apt-utils \
+    ca-certificates \
+    curl \
+    wget \
+    git \
+    unzip \
+    # Forensics meta-package (includes many stego tools)
+    forensics-all \
+    foremost \
+    # Image analysis
+    binwalk \
+    libimage-exiftool-perl \
+    pngtools \
+    pngcheck \
+    imagemagick \
+    graphicsmagick \
+    # Stego tools from repos
+    outguess \
+    steghide \
+    stegosuite \
+    # Development tools for building from source
+    build-essential \
+    cmake \
+    autotools-dev \
+    automake \
+    libtool \
+    pkg-config \
+    # Libraries needed for various tools
+    libevent-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libmcrypt-dev \
+    libmhash-dev \
+    zlib1g-dev \
+    # Audio tools
+    ffmpeg \
+    sox \
+    audacity \
+    sonic-visualiser \
+    # Text/hex editors
+    hexedit \
+    xxd \
+    # Python 3 environment
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-dev \
+    python3-setuptools \
+    python3-wheel \
+    # Ruby for zsteg
+    ruby \
+    ruby-dev \
+    # Java for GUI tools (OpenStego, Stegsolve)
+    default-jre-headless \
+    # Password cracking/generation utilities
+    crunch \
+    cewl \
+    john \
+    # Misc utilities
+    bsdmainutils \
+    file \
+    atomicparsley \
+    mediainfo \
+    # VNC/SSH for GUI access (optional)
+    openssh-server \
+    tigervnc-standalone-server \
+    tigervnc-common \
+    novnc \
+    xfce4 \
+    xfce4-terminal \
+    dbus-x11 \
+    && \
+    # Clean up apt cache to reduce image size
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# =============================================================================
+# Stage 2: Install Python packages
+# =============================================================================
+# Install Python packages globally (avoiding externally-managed-environment issue)
+RUN pip3 install --break-system-packages --no-cache-dir \
+    # Core utilities
+    python-magic \
+    tqdm \
+    pillow \
+    numpy \
+    scipy \
+    # Stego tools
+    stegoveritas \
+    stegano \
+    stepic \
+    # Additional useful packages
+    pycryptodome \
+    click
+
+# Install stegoveritas dependencies
+RUN stegoveritas_install_deps || true
+
+# =============================================================================
+# Stage 3: Install Ruby gems
+# =============================================================================
+RUN gem install zsteg --no-document
+
+# =============================================================================
+# Stage 4: Install tools from source/releases
+# =============================================================================
+
+# Copy installation scripts
 COPY install /tmp/install
-RUN chmod a+x /tmp/install/*.sh && \
-    for i in /tmp/install/*.sh;do echo $i && $i;done && \
+RUN chmod a+x /tmp/install/*.sh
+
+# Run each installation script
+RUN for script in /tmp/install/*.sh; do \
+        echo "=== Running: $script ===" && \
+        bash "$script" || echo "Warning: $script had errors"; \
+    done && \
     rm -rf /tmp/install
 
-# Use this section to try new installation scripts.
-# All previous steps will be cached
-#
-# COPY install_dev /tmp/install
-# RUN find /tmp/install -name '*.sh' -exec chmod a+x {} + && \
-#     for f in $(ls /tmp/install/* | sort );do /bin/sh $f;done && \
-#     rm -rf /tmp/install
+# =============================================================================
+# Stage 5: Create non-root user for security
+# =============================================================================
+RUN groupadd -r stego && \
+    useradd -r -g stego -d /home/stego -s /bin/bash -m stego && \
+    # Create directories with proper permissions
+    mkdir -p /data /examples && \
+    chown -R stego:stego /data /home/stego
 
+# =============================================================================
+# Stage 6: Copy project files
+# =============================================================================
 COPY examples /examples
-
 COPY scripts /opt/scripts
+
+# Make scripts executable and fix permissions
 RUN find /opt/scripts -name '*.sh' -exec chmod a+x {} + && \
-    find /opt/scripts -name '*.py' -exec chmod a+x {} +
+    find /opt/scripts -name '*.py' -exec chmod a+x {} + && \
+    chown -R stego:stego /opt/scripts /examples
+
+# Add scripts to PATH
 ENV PATH="/opt/scripts:${PATH}"
 
+# =============================================================================
+# Final configuration
+# =============================================================================
 WORKDIR /data
+
+# Switch to non-root user by default
+# Comment out to run as root if needed for certain tools
+USER stego
+
+# Default command
+CMD ["/bin/bash"]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,26 +1,28 @@
 # =============================================================================
-# Stego-Toolkit: Modern Steganography CTF Toolkit
-# 2025 Refresh - Modernized Docker Image
+# Stego-Toolkit: CLI-Only Version (Lightweight)
+# 2025 Refresh - No GUI packages, minimal footprint
+# =============================================================================
+# Build: docker build -f Dockerfile.cli -t stego-toolkit:cli .
+# Run:   docker run -it --rm -v $(pwd)/data:/data stego-toolkit:cli
 # =============================================================================
 FROM debian:bookworm-slim
 
 # Image metadata
-LABEL org.opencontainers.image.title="Stego-Toolkit"
-LABEL org.opencontainers.image.description="Dockerized collection of steganography tools for CTF challenges"
-LABEL org.opencontainers.image.version="2.0.0"
+LABEL org.opencontainers.image.title="Stego-Toolkit CLI"
+LABEL org.opencontainers.image.description="Lightweight CLI-only steganography toolkit for CTF challenges"
+LABEL org.opencontainers.image.version="2.0.0-cli"
 LABEL org.opencontainers.image.authors="DominicBreuker (original), consigcody94 (2025 refresh)"
 LABEL org.opencontainers.image.source="https://github.com/consigcody94/stego-toolkit"
 LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.variant="cli"
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Set locale for consistent behavior
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
 # =============================================================================
-# Stage 1: Install system packages
+# Install CLI-only system packages (NO GUI dependencies)
 # =============================================================================
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
@@ -31,9 +33,10 @@ RUN apt-get update && apt-get upgrade -y && \
     wget \
     git \
     unzip \
-    # Forensics meta-package (includes many stego tools)
-    forensics-all \
+    # Forensics tools (individual packages, not meta-package)
     foremost \
+    scalpel \
+    sleuthkit \
     # Image analysis
     binwalk \
     libimage-exiftool-perl \
@@ -44,7 +47,6 @@ RUN apt-get update && apt-get upgrade -y && \
     # Stego tools from repos
     outguess \
     steghide \
-    stegosuite \
     # Development tools for building from source
     build-essential \
     cmake \
@@ -59,11 +61,9 @@ RUN apt-get update && apt-get upgrade -y && \
     libmcrypt-dev \
     libmhash-dev \
     zlib1g-dev \
-    # Audio tools
+    # Audio tools (CLI only)
     ffmpeg \
     sox \
-    audacity \
-    sonic-visualiser \
     # Text/hex editors
     hexedit \
     xxd \
@@ -77,7 +77,7 @@ RUN apt-get update && apt-get upgrade -y && \
     # Ruby for zsteg
     ruby \
     ruby-dev \
-    # Java for GUI tools (OpenStego, Stegsolve)
+    # Java for CLI tools (headless)
     default-jre-headless \
     # Password cracking/generation utilities
     crunch \
@@ -88,94 +88,78 @@ RUN apt-get update && apt-get upgrade -y && \
     file \
     atomicparsley \
     mediainfo \
-    # VNC/SSH for GUI access (optional)
-    openssh-server \
-    tigervnc-standalone-server \
-    tigervnc-common \
-    novnc \
-    xfce4 \
-    xfce4-terminal \
-    dbus-x11 \
     && \
     # Clean up apt cache to reduce image size
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # =============================================================================
-# Stage 2: Install Python packages
+# Install Python packages
 # =============================================================================
-# Install Python packages globally (avoiding externally-managed-environment issue)
 RUN pip3 install --break-system-packages --no-cache-dir \
-    # Core utilities
     python-magic \
     tqdm \
     pillow \
     numpy \
     scipy \
-    # Stego tools
     stegoveritas \
     stegano \
     stepic \
-    # Additional useful packages
     pycryptodome \
     click
 
-# Install stegoveritas dependencies
+# Install stegoveritas dependencies (skip GUI deps)
 RUN stegoveritas_install_deps || true
 
 # =============================================================================
-# Stage 3: Install Ruby gems
+# Install Ruby gems
 # =============================================================================
 RUN gem install zsteg --no-document
 
 # =============================================================================
-# Stage 4: Install tools from source/releases
+# Install tools from source/releases
 # =============================================================================
-
-# Copy installation scripts
 COPY install /tmp/install
 RUN chmod a+x /tmp/install/*.sh
 
-# Run each installation script
+# Run installation scripts (skip GUI-only tools)
 RUN for script in /tmp/install/*.sh; do \
-        echo "=== Running: $script ===" && \
-        bash "$script" || echo "Warning: $script had errors"; \
+        # Skip GUI-only tools
+        case "$(basename $script)" in \
+            deepsound.sh|openpuff.sh|steganabara.sh|steg.sh|vnc_server.sh|ssh_server.sh) \
+                echo "=== Skipping GUI tool: $script ===" ;; \
+            *) \
+                echo "=== Running: $script ===" && \
+                bash "$script" || echo "Warning: $script had errors" ;; \
+        esac \
     done && \
     rm -rf /tmp/install
 
 # =============================================================================
-# Stage 5: Create non-root user for security
+# Create non-root user for security
 # =============================================================================
 RUN groupadd -r stego && \
     useradd -r -g stego -d /home/stego -s /bin/bash -m stego && \
-    # Create directories with proper permissions
     mkdir -p /data /examples && \
     chown -R stego:stego /data /home/stego
 
 # =============================================================================
-# Stage 6: Copy project files
+# Copy project files
 # =============================================================================
 COPY examples /examples
 COPY scripts /opt/scripts
 COPY mcp /opt/mcp
 
-# Make scripts executable and fix permissions
 RUN find /opt/scripts -name '*.sh' -exec chmod a+x {} + && \
     find /opt/scripts -name '*.py' -exec chmod a+x {} + && \
     chmod a+x /opt/mcp/*.py && \
     chown -R stego:stego /opt/scripts /examples /opt/mcp
 
-# Add scripts to PATH
 ENV PATH="/opt/scripts:${PATH}"
 
 # =============================================================================
 # Final configuration
 # =============================================================================
 WORKDIR /data
-
-# Switch to non-root user by default
-# Comment out to run as root if needed for certain tools
 USER stego
-
-# Default command
 CMD ["/bin/bash"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,241 @@
+# =============================================================================
+# Stego-Toolkit: GPU-Accelerated Version (NVIDIA CUDA)
+# 2025 Refresh - GPU support for hashcat, john, and ML-based stego tools
+# =============================================================================
+# Prerequisites:
+#   - NVIDIA GPU with CUDA support
+#   - nvidia-container-toolkit installed on host
+#   - Docker >= 19.03
+#
+# Build: docker build -f Dockerfile.gpu -t stego-toolkit:gpu .
+# Run:   docker run --gpus all -it --rm -v $(pwd)/data:/data stego-toolkit:gpu
+# =============================================================================
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+
+# Image metadata
+LABEL org.opencontainers.image.title="Stego-Toolkit GPU"
+LABEL org.opencontainers.image.description="GPU-accelerated steganography toolkit with CUDA support"
+LABEL org.opencontainers.image.version="2.0.0-gpu"
+LABEL org.opencontainers.image.authors="DominicBreuker (original), consigcody94 (2025 refresh)"
+LABEL org.opencontainers.image.source="https://github.com/consigcody94/stego-toolkit"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.variant="gpu"
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# CUDA environment
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH="${CUDA_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}"
+
+# =============================================================================
+# Install system packages
+# =============================================================================
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+    # Core utilities
+    apt-utils \
+    ca-certificates \
+    curl \
+    wget \
+    git \
+    unzip \
+    gnupg \
+    lsb-release \
+    software-properties-common \
+    # Forensics tools
+    foremost \
+    sleuthkit \
+    # Image analysis
+    binwalk \
+    libimage-exiftool-perl \
+    pngtools \
+    pngcheck \
+    imagemagick \
+    graphicsmagick \
+    # Stego tools from repos
+    outguess \
+    steghide \
+    # Development tools
+    build-essential \
+    cmake \
+    autotools-dev \
+    automake \
+    libtool \
+    pkg-config \
+    # Libraries
+    libevent-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libmcrypt-dev \
+    libmhash-dev \
+    zlib1g-dev \
+    # OpenCL for GPU tools
+    ocl-icd-libopencl1 \
+    opencl-headers \
+    clinfo \
+    # Audio tools
+    ffmpeg \
+    sox \
+    # Text/hex editors
+    hexedit \
+    xxd \
+    # Python 3 environment
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-dev \
+    python3-setuptools \
+    python3-wheel \
+    # Ruby for zsteg
+    ruby \
+    ruby-dev \
+    # Java headless
+    default-jre-headless \
+    # Password cracking utilities
+    crunch \
+    cewl \
+    # Misc utilities
+    bsdmainutils \
+    file \
+    atomicparsley \
+    mediainfo \
+    p7zip-full \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# =============================================================================
+# Install hashcat (GPU-accelerated password cracker)
+# =============================================================================
+RUN cd /tmp && \
+    HASHCAT_VERSION="6.2.6" && \
+    wget -q "https://hashcat.net/files/hashcat-${HASHCAT_VERSION}.tar.gz" && \
+    tar -xzf "hashcat-${HASHCAT_VERSION}.tar.gz" && \
+    cd "hashcat-${HASHCAT_VERSION}" && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf /tmp/hashcat*
+
+# =============================================================================
+# Install John the Ripper (Jumbo with GPU support)
+# =============================================================================
+RUN cd /tmp && \
+    git clone --depth 1 https://github.com/openwall/john.git john-jumbo && \
+    cd john-jumbo/src && \
+    ./configure --enable-opencl && \
+    make -j$(nproc) && \
+    cp -r ../run /opt/john && \
+    ln -sf /opt/john/john /usr/local/bin/john-gpu && \
+    cd / && \
+    rm -rf /tmp/john-jumbo
+
+# =============================================================================
+# Install Python packages (including GPU-accelerated ML libraries)
+# =============================================================================
+RUN pip3 install --break-system-packages --no-cache-dir \
+    # Core utilities
+    python-magic \
+    tqdm \
+    pillow \
+    numpy \
+    scipy \
+    # Stego tools
+    stegoveritas \
+    stegano \
+    stepic \
+    # Crypto
+    pycryptodome \
+    click \
+    # ML/Deep Learning for steganalysis (GPU-accelerated)
+    torch \
+    torchvision \
+    tensorflow \
+    # Additional GPU utilities
+    cupy-cuda12x
+
+# Install stegoveritas dependencies
+RUN stegoveritas_install_deps || true
+
+# =============================================================================
+# Install Ruby gems
+# =============================================================================
+RUN gem install zsteg --no-document
+
+# =============================================================================
+# Install tools from source/releases
+# =============================================================================
+COPY install /tmp/install
+RUN chmod a+x /tmp/install/*.sh
+
+# Run installation scripts (skip GUI-only tools for CLI GPU image)
+RUN for script in /tmp/install/*.sh; do \
+        case "$(basename $script)" in \
+            deepsound.sh|openpuff.sh|steganabara.sh|steg.sh|vnc_server.sh|ssh_server.sh|wine.sh) \
+                echo "=== Skipping GUI tool: $script ===" ;; \
+            *) \
+                echo "=== Running: $script ===" && \
+                bash "$script" || echo "Warning: $script had errors" ;; \
+        esac \
+    done && \
+    rm -rf /tmp/install
+
+# =============================================================================
+# Create GPU benchmark and test script
+# =============================================================================
+RUN cat > /usr/local/bin/gpu-test << 'GPUEOF'
+#!/bin/bash
+echo "=== GPU Test for Stego-Toolkit ==="
+echo ""
+echo "NVIDIA Driver Info:"
+nvidia-smi || echo "nvidia-smi not available"
+echo ""
+echo "CUDA Version:"
+nvcc --version 2>/dev/null || echo "nvcc not in PATH"
+echo ""
+echo "OpenCL Devices:"
+clinfo -l 2>/dev/null || echo "clinfo not available"
+echo ""
+echo "Hashcat GPU Test:"
+hashcat -I 2>/dev/null || echo "hashcat GPU info not available"
+echo ""
+echo "PyTorch CUDA:"
+python3 -c "import torch; print(f'PyTorch CUDA available: {torch.cuda.is_available()}'); print(f'CUDA devices: {torch.cuda.device_count()}')" 2>/dev/null || echo "PyTorch not available"
+echo ""
+echo "TensorFlow GPU:"
+python3 -c "import tensorflow as tf; print(f'TensorFlow GPUs: {len(tf.config.list_physical_devices(\"GPU\"))}')" 2>/dev/null || echo "TensorFlow not available"
+GPUEOF
+RUN chmod +x /usr/local/bin/gpu-test
+
+# =============================================================================
+# Create non-root user for security
+# =============================================================================
+RUN groupadd -r stego && \
+    useradd -r -g stego -d /home/stego -s /bin/bash -m stego && \
+    mkdir -p /data /examples && \
+    chown -R stego:stego /data /home/stego
+
+# =============================================================================
+# Copy project files
+# =============================================================================
+COPY examples /examples
+COPY scripts /opt/scripts
+COPY mcp /opt/mcp
+
+RUN find /opt/scripts -name '*.sh' -exec chmod a+x {} + && \
+    find /opt/scripts -name '*.py' -exec chmod a+x {} + && \
+    chmod a+x /opt/mcp/*.py && \
+    chown -R stego:stego /opt/scripts /examples /opt/mcp
+
+ENV PATH="/opt/scripts:/opt/john:${PATH}"
+
+# =============================================================================
+# Final configuration
+# =============================================================================
+WORKDIR /data
+USER stego
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,230 +1,325 @@
 # Steganography Toolkit
 
-This project is a Docker image useful for solving Steganography challenges as those you can find at CTF platforms like [hackthebox.eu](https://www.hackthebox.eu/).
-The image comes pre-installed with many popular tools (see list [below](#tools)) and several screening scripts you can use check simple things (for instance, run `check_jpg.sh image.jpg` to get a report for a JPG file).
+[![CI - Build and Test](https://github.com/consigcody94/stego-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/consigcody94/stego-toolkit/actions/workflows/ci.yml)
+[![Docker](https://img.shields.io/badge/docker-ready-blue.svg)](https://github.com/consigcody94/stego-toolkit)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[![Docker build status](https://img.shields.io/docker/build/mariobehling/loklak.svg)](https://hub.docker.com/r/dominicbreuker/stego-toolkit/)
+A comprehensive Docker image for solving steganography challenges in CTF competitions. Pre-installed with 30+ popular tools and automated screening scripts for quick analysis.
 
-[![Hack The Box](https://www.hackthebox.eu/badge/image/6255)](https://www.hackthebox.eu/profile/6255)
+> **2025 Refresh**: This is a modernized fork of [DominicBreuker/stego-toolkit](https://github.com/DominicBreuker/stego-toolkit) with updated tools, improved scripts, and CI/CD.
 
-## Usage
+---
 
-First make sure you have Docker installed ([how to](https://docs.docker.com/engine/installation/)).
-Then you can use the shell scripts `bin/build.sh` and `bin/run.sh` in this repo to build the image and run the container.
-You will be dropped into a bash shell inside the container.
-It will have the `data` folder mounted, into which you can put the files to analyze.
+## What's New in 2025 Refresh
 
-If you don't use the scripts, follow these steps:
-1. Build image (`docker build -t <image_name> .`) or pull from Docker hub (`docker pull dominicbreuker/stego-toolkit`)
-2. Start a container with your files mounted to the folder `/data` (`docker run -it <image_name> -v /local/folder/with/data:/data /bin/bash`)
-3. Use CLI tools and screening scripts on your files: e.g., run `check_jpg.sh image.jpg` to create a quick report, or run `brute_jpg.sh image.jpg wordlist.txt` to try extracting hidden data with various tools and passwords
-4. If you want to run GUI tools use one of these two ways:
-  - Run `start_ssh.sh` and connect to your container with X11 forwarding
-  - Run `start_vnc.sh` and connect to the container's Desktop through your browser
+- **Modern Base Image**: Debian Bookworm (slim) instead of Debian Stretch
+- **New Tools Added**:
+  - [stegseek](https://github.com/RickdeJager/stegseek) - Lightning-fast steghide cracker (cracks rockyou.txt in <2 seconds!)
+  - [stegcracker](https://github.com/Paradoxis/StegCracker) - Steghide brute-force utility
+  - [hexyl](https://github.com/sharkdp/hexyl) - Modern hex viewer with colored output
+- **Updated Tools**: All existing tools updated to latest versions
+- **Improved Scripts**: Better UX with colored output, `--help` flags, and progress indicators
+- **Security**: Non-root user by default, minimal image with `--no-install-recommends`
+- **CI/CD**: GitHub Actions for automated builds and smoke tests
+- **Python 3 Only**: Removed Python 2 dependencies
 
-Check out the following sections for more information:
-- What tools are installed? Go [here](#tools)
-- What scripts can I run to quickly screen files automatically or brute force them? Go [here](#screening-scripts)
-- How can I play with different Steganography examples to see if I can break them? Go [here](#steganography-examples)
-- How can I run GUI tools inside the container? go [here](#gui-and-containers)
+---
 
-## Demo
+## Quick Start
 
-Start with `docker run -it --rm -v $(pwd)/data:/data dominicbreuker/stego-toolkit /bin/bash`.
-You will be dropped into a container shell in work dir `/data`.
-Your host folder `$(pwd)/data` will be mounted and the images inside will be accessible.
+### 5-Minute Setup
 
-![animated demo gif](https://i.imgur.com/UW8CKFV.gif)
+```bash
+# Clone the repository
+git clone https://github.com/consigcody94/stego-toolkit.git
+cd stego-toolkit
+
+# Build the Docker image
+./bin/build.sh
+# Or: docker build -t stego-toolkit .
+
+# Run the toolkit with your files mounted
+./bin/run.sh
+# Or: docker run -it --rm -v $(pwd)/data:/data stego-toolkit
+
+# Inside the container, analyze a file
+check_jpg.sh suspicious.jpg
+
+# Brute-force with stegseek (FAST!)
+stegseek suspicious.jpg rockyou.txt
+```
+
+### Pull Pre-built Image (when available)
+
+```bash
+docker pull ghcr.io/consigcody94/stego-toolkit:latest
+docker run -it --rm -v $(pwd)/data:/data ghcr.io/consigcody94/stego-toolkit
+```
+
+---
 
 ## Tools
 
-Many different Linux and Windows tools are installed.
-Windows tools are supported with [Wine](https://www.winehq.org/).
-Some tools can be used on the command line while others require GUI support!
+### New in 2025 Refresh
 
-### Command line interface tools
+| Tool | Description | Usage |
+|------|-------------|-------|
+| [stegseek](https://github.com/RickdeJager/stegseek) | Lightning-fast steghide cracker. Cracks rockyou.txt in under 2 seconds! | `stegseek stego.jpg wordlist.txt` |
+| [stegcracker](https://github.com/Paradoxis/StegCracker) | Steganography brute-force utility | `stegcracker stego.jpg wordlist.txt` |
+| [hexyl](https://github.com/sharkdp/hexyl) | Modern hex viewer with colored output | `hexyl stego.jpg` |
 
-These tools can be used on the command line.
-All you have to do is start a container and mount the steganography files you want to check.
+### General Screening Tools
 
-#### General screening tools
+| Tool | Description | Usage |
+|------|-------------|-------|
+| file | Identify file type via magic numbers | `file stego.jpg` |
+| exiftool | Extract/edit metadata | `exiftool stego.jpg` |
+| binwalk | Find embedded files | `binwalk stego.jpg` |
+| strings | Extract readable strings | `strings stego.jpg` |
+| foremost | Carve out embedded files | `foremost stego.jpg` |
+| pngcheck | Validate PNG structure | `pngcheck stego.png` |
+| identify | ImageMagick file info | `identify -verbose stego.jpg` |
+| ffmpeg | Audio/video analysis | `ffmpeg -v info -i stego.mp3 -f null -` |
 
-Tools to run in the beginning.
-Allow you to get a broad idea of what you are dealing with.
+### Steganography Detection Tools
 
-|Tool          |Description       |How to use     |
-|--------------|------------------|---------------|
-| file         | Check out what kind of file you have | `file stego.jpg` |
-| exiftool     | Check out metadata of media files | `exiftool stego.jpg` |
-| binwalk      | Check out if other files are embedded/appended | `binwalk stego.jpg`
-| strings      | Check out if there are interesting readable characters in the file | `strings stego.jpg`
-| foremost     | Carve out embedded/appended files | `foremost stego.jpg`
-| pngcheck     | Get details on a PNG file (or find out is is actually something else) | `pngcheck stego.png`
-| identify     | [GraphicMagick](http://www.graphicsmagick.org/) tool to check what kind of image a file is. Checks also if image is corrupted. | `identify -verbose stego.jpg`
-| ffmpeg       | ffmpeg can be used to check integrity of audio files and let it report infos and errors | `ffmpeg -v info -i stego.mp3 -f null -` to recode the file and throw away the result
+| Tool | File Types | Description | Usage |
+|------|-----------|-------------|-------|
+| [stegoveritas](https://github.com/bannsec/stegoVeritas) | JPG, PNG, GIF, TIFF, BMP | Comprehensive analysis suite | `stegoveritas stego.jpg` |
+| [zsteg](https://github.com/zed-0xff/zsteg) | PNG, BMP | LSB stego detection | `zsteg -a stego.png` |
+| stegdetect | JPG | Statistical stego detection | `stegdetect stego.jpg` |
+| stegbreak | JPG | Dictionary attack for outguess/jphide/jsteg | `stegbreak -t o -f wordlist.txt stego.jpg` |
 
+### Steganography Tools (Hide/Extract)
 
-#### Tools detecting steganography
+| Tool | File Types | How to Hide | How to Extract |
+|------|-----------|-------------|----------------|
+| [steghide](http://steghide.sourceforge.net/) | JPG, BMP, WAV, AU | `steghide embed -ef secret.txt -cf cover.jpg -p pass -sf stego.jpg` | `steghide extract -sf stego.jpg -p pass` |
+| [jsteg](https://github.com/lukechampine/jsteg) | JPG | `jsteg hide cover.jpg secret.txt stego.jpg` | `jsteg reveal stego.jpg output.txt` |
+| [openstego](https://github.com/syvaidya/openstego) | PNG | `openstego embed -mf secret.txt -cf cover.png -p pass -sf stego.png` | `openstego extract -sf stego.png -p pass` |
+| [outguess](https://github.com/resurrecting-open-source-projects/outguess) | JPG | `outguess -k pass -d secret.txt cover.jpg stego.jpg` | `outguess -r -k pass stego.jpg output.txt` |
+| [stegano](https://github.com/cedricbonhomme/Stegano) | PNG | `stegano-lsb hide --input cover.png -f secret.txt -o stego.png` | `stegano-lsb reveal -i stego.png` |
+| [LSBSteg](https://github.com/RobinDavid/LSB-Steganography) | PNG, BMP | `LSBSteg encode -i cover.png -o stego.png -f secret.txt` | `LSBSteg decode -i stego.png -o output.txt` |
 
-Tools designed to detect steganography in files.
-Mostly perform statistical tests.
-They will reveal hidden messages only in simple cases.
-However, they may provide hints what to look for if they find interesting irregularities.
+### GUI Tools
 
-|Tool          |File types                |Description       |How to use     |
-|--------------|--------------------------|------------------|---------------|
-| [stegoVeritas](https://github.com/bannsec/stegoVeritas) | Images (JPG, PNG, GIF, TIFF, BMP) | A wide variety of simple and advanced checks. Check out `stegoveritas.py -h`. Checks metadata, creates many transformed images and saves them to a directory, Brute forces LSB, ... | `stegoveritas.py stego.jpg` to run all checks |
-| [zsteg](https://github.com/zed-0xff/zsteg) | Images (PNG, BMP) | Detects various LSB stego, also openstego and the [Camouflage tool](http://camouflage.unfiction.com/) | `zsteg -a stego.jpg` to run all checks |
-| [stegdetect](http://old-releases.ubuntu.com/ubuntu/pool/universe/s/stegdetect) | Images (JPG) | Performs statistical tests to find if a stego tool was used (jsteg, outguess, jphide, ...). Check out `man stegdetect` for details. | `stegdetect stego.jpg` |
-| [stegbreak](https://linux.die.net/man/1/stegbreak) | Images (JPG) | Brute force cracker for JPG images. Claims it can crack `outguess`, `jphide` and `jsteg`. | `stegbreak -t o -f wordlist.txt stego.jpg`, use `-t o` for outguess, `-t p` for jphide or `-t j` for jsteg |
+These tools require X11 or VNC. See [GUI and Containers](#gui-and-containers).
 
+| Tool | Description | Command |
+|------|-------------|---------|
+| [Stegsolve](http://www.caesum.com/handbook/stego.htm) | Image analysis, bit plane viewer | `stegsolve` |
+| [Sonic Visualiser](https://www.sonicvisualiser.org/) | Audio spectrogram analysis | `sonic-visualiser` |
+| [Stegosuite](https://stegosuite.org/) | Image steganography GUI | `stegosuite` |
 
-#### Tools actually doing steganography
+---
 
-Tools you can use to hide messages and reveal them afterwards.
-Some encrypt the messages before hiding them.
-If they do, they require a password.
-If you have a hint what kind of tool was used or what password might be right, try these tools.
-Some tools are supported by the brute force scripts available in this Docker image.
+## Screening Scripts
 
-|Tool          |File types                |Description       |How to hide    | How to recover |
-|--------------|--------------------------|------------------|---------------|----------------|
-| [AudioStego](https://github.com/danielcardeenas/AudioStego) | Audio (MP3 / WAV) | Details on how it works are in this [blog post](https://danielcardeenas.github.io/audiostego.html) | `hideme cover.mp3 secret.txt && mv ./output.mp3 stego.mp3` | `hideme stego.mp3 -f && cat output.txt` |
-| [jphide/jpseek](http://linux01.gwdg.de/~alatham/stego.html) | Image (JPG) | Pretty old tool from [here](http://linux01.gwdg.de/~alatham/stego.html). Here, the version from [here](https://github.com/mmayfield1/SSAK) is installed since the original one crashed all the time. It prompts for a passphrase interactively! | `jphide cover.jpg stego.jpg secret.txt` | `jpseek stego.jpg output.txt` |
-| [jsteg](https://github.com/lukechampine/jsteg) | Image (JPG) | LSB stego tool. Does not encrypt the message. | `jsteg hide cover.jpg secret.txt stego.jpg` | `jsteg reveal cover.jpg output.txt` |
-| [mp3stego](http://www.petitcolas.net/steganography/mp3stego/) | Audio (MP3) | Old program. Encrypts and then hides a message (3DES encryption!). Windows tool running in Wine. Requires WAV input (may throw errors for certain WAV files. what works for me is e.g.: `ffmpeg -i audio.mp3 -flags bitexact audio.wav`). Important: use absolute path only! | `mp3stego-encode -E secret.txt -P password /path/to/cover.wav /path/to/stego.mp3` | `mp3stego-decode -X -P password /path/to/stego.mp3 /path/to/out.pcm /path/to/out.txt`
-| [openstego](https://github.com/syvaidya/openstego) | Images (PNG) | Various LSB stego algorithms (check out this [blog](http://syvaidya.blogspot.de/)). Still maintained. | `openstego embed -mf secret.txt -cf cover.png -p password -sf stego.png` | `openstego extract -sf openstego.png -p abcd -xf output.txt ` (leave out -xf to create file with original name!) |
-| [outguess](https://packages.debian.org/sid/utils/outguess) | Images (JPG) | Uses "redundant bits" to hide data. Comes in two versions: old=`outguess-0.13` taken from [here](https://github.com/mmayfield1/SSAK) and new=`outguess` from the package repos. To recover, you must use the one used for hiding. | `outguess -k password -d secret.txt cover.jpg stego.jpg` | `outguess  -r -k password stego.jpg output.txt` |
-| [spectrology](https://github.com/solusipse/spectrology) | Audio (WAV) | Encodes an image in the spectrogram of an audio file. | `TODO` | Use GUI tool `sonic-visualiser` |
-| [stegano](https://github.com/cedricbonhomme/Stegano) | Images (PNG) | Hides data with various (LSB-based) methods. Provides also some screening tools. | `stegano-lsb hide --input cover.jpg -f secret.txt -e UTF-8 --output stego.png` or `stegano-red hide --input cover.png -m "secret msg" --output stego.png` or `stegano-lsb-set hide --input cover.png -f secret.txt -e UTF-8 -g $GENERATOR --output stego.png` for various generators (`stegano-lsb-set list-generators`) | `stegano-lsb reveal -i stego.png -e UTF-8 -o output.txt` or `stegano-red reveal -i stego.png` or `stegano-lsb-set reveal -i stego.png -e UTF-8 -g $GENERATOR -o output.txt`
-| [Steghide](http://steghide.sourceforge.net/) | Images (JPG, BMP) and Audio (WAV, AU) | Versatile and mature tool to encrypt and hide data. | `steghide embed -f -ef secret.txt -cf cover.jpg -p password -sf stego.jpg` | `steghide extract -sf stego.jpg -p password -xf output.txt`
-| [cloackedpixel](https://github.com/livz/cloacked-pixel) | Images (PNG) | LSB stego tool for images | `cloackedpixel hide cover.jpg secret.txt password` creates `cover.jpg-stego.png` | `cloackedpixel extract cover.jpg-stego.png output.txt password`
-| [LSBSteg](https://github.com/RobinDavid/LSB-Steganography) | Images (PNG, BMP, ...) in uncompressed formats | Simple LSB tools with very nice and readable Python code | `LSBSteg encode -i cover.png -o stego.png -f secret.txt` | `LSBSteg decode -i stego.png -o output.txt` |
-| [f5](https://github.com/jackfengji/f5-steganography) | Images (JPG) | F5 Steganographic Algorithm with detailed info on the process | `f5 -t e -i cover.jpg -o stego.jpg -d 'secret message'` | `f5 -t x -i stego.jpg 1> output.txt` |
-| [stegpy](https://github.com/dhsdshdhk/stegpy) | Images (PNG, GIF, BMP, WebP) and Audio (WAV) | Simple steganography program based on the LSB method | `stegpy secret.jpg cover.png` | `stegpy _cover.png` |
+Automated scripts for quick file analysis. All scripts support `--help` for usage information.
 
+### Check Scripts (Analysis)
 
-### Steganography GUI tools
+```bash
+# Analyze JPG files
+check_jpg.sh suspicious.jpg
+check_jpg.sh -o ./reports suspicious.jpg  # Save detailed reports
 
-All tools below have graphical user interfaces and cannot be used through the command line.
-To run them, you must make an X11 server available inside the container.
-Two ways are supported:
-- run `start_ssh.sh` to fire up an SSH server. Connect afterwards with X11 forwarding. Requires an X11 server on your host!
-- run `start_vnc.sh` to fire up a VNC server + client. Connect afterwards with your browser to port 6901 and you get an Xfce desktop. No host dependencies!
+# Analyze PNG files
+check_png.sh suspicious.png
+check_png.sh --verbose suspicious.png
+```
 
-Alternatively, find other ways to make X11 available inside the container.
-Many different ways are possible (e.g., [mount UNIX sockets](https://medium.com/@pigiuz/hw-accelerated-gui-apps-on-docker-7fd424fe813e)).
+### Brute-Force Scripts (Password Cracking)
 
-|Tool          |File types                |Description       |How to start    |
-|--------------|--------------------------|------------------|----------------|
-| [Steg](http://www.fabionet.org/) | Images (JPG, TIFF, PNG, BMP) | Handles many file types and implements different methods | `steg` |
-| [Steganabara](http://www.caesum.com/handbook/stego.htm) (The [original link](http://www.freewebs.com/quangntenemy/steganabara/index.html) is broken) | Images (???) | Interactively transform images until you find something | `steganabara`|
-| [Stegsolve](http://www.caesum.com/handbook/stego.htm) | Images (???) | Interactively transform images, view color schemes separately, ... | `stegsolve` |
-| [SonicVisualiser](http://www.sonicvisualiser.org/) | Audio (???) | Visualizing audio files in waveform, display spectrograms, ... | `sonic-visualiser` |
-| [Stegosuite](https://stegosuite.org/) | Images (JPG, GIF, BMP) | Can encrypt and hide data in images. Actively developed. | `stegosuite` |
-| [OpenPuff](http://embeddedsw.net/OpenPuff_Steganography_Home.html) | Images, Audio, Video (many formats) | Sophisticated tool with long history. Still maintained. Windows tool running in wine. | `openpuff` |
-| [DeepSound](http://jpinsoft.net/deepsound) | Audio (MP3, WAV) | Audio stego tool trusted by Mr. Robot himself. Windows tool running in wine (very hacky, requires VNC and runs in virtual desktop, MP3 broken due to missing DLL!) | `deepsound` only in VNC session |
-| [cloackedpixel-analyse](https://github.com/livz/cloacked-pixel) | Images (PNG) | LSB stego visualization for PNGs - use it to detect suspiciously random LSB values in images (values close to 0.5 may indicate encrypted data is embedded) | `cloackedpixel-analyse image.png` |
+```bash
+# JPG brute-force (uses stegseek by default - FAST!)
+brute_jpg.sh suspicious.jpg wordlist.txt
+brute_jpg.sh -s suspicious.jpg rockyou.txt  # Stegseek-only mode
+brute_jpg.sh -t 8 suspicious.jpg wordlist.txt  # 8 threads
 
+# PNG brute-force
+brute_png.sh suspicious.png wordlist.txt
 
-### Screening scripts
+# Python brute-forcer (supports multiple tools)
+pybrute.py -f stego.jpg -w wordlist.txt steghide
+pybrute.py -f stego.jpg -w wordlist.txt -t 8 outguess
+```
 
-Many tools above do not require interaction with a GUI.
-Therefore, you can easily automate some workflows to do basic screening of files potentially containing hidden messages.
-Since the applicable tools differ by filet type, each file type has different scripts.
+### Wordlist Generation
 
+```bash
+# Generate wordlist from website
+cewl -d 2 -m 6 https://target.com > custom.txt
 
-For each file type, there are two kinds of scripts:
-- `XXX_check.sh <stego-file>`: runs basic screening tools and creates a report (+ possibly a directory with reports in files)
-- `XXX_brute.sh <stego-file> <wordlist>`: tries to extract a hidden message from a stego file with various tools using a wordlist (`cewl`, `john` and `crunch` are installed to generate lists - keep them small).
+# Generate pattern-based wordlist
+crunch 6 6 abcdefghijklmnopqrstuvwxyz -t @@1984 > pattern.txt
 
-The following file types are supported:
-- JPG: `check_jpg.h` and `brute_jpg.sh` (brute running `steghide`, `outguess`, `outguess-0.13`, `stegbreak`, `stegoveritas.py -bruteLSB`)
-- PNG: `check_png.h` and `brute_png.sh` (brute running `openstego` and `stegoveritas.py -bruteLSB`)
+# Expand wordlist with john rules
+john --wordlist=base.txt --rules=Single --stdout > expanded.txt
+```
 
+---
 
-### Wordlist generation
+## Steganography Examples
 
-The brute forcing scripts above need wordlists.
-Imho it will very likely not help to use huge standard wordlists like rockyou.
-The scripts are too slow for it and stego challenges seem to not be designed for
-this.
-A more probable scenario is that you have a hunch what the password could be but
-you do not know exactly.
+The image includes sample files for practice:
 
-For these cases, several tools to generate wordlists are included:
-- [john](http://www.openwall.com/john/): the community enhanced version of John the Ripper can expand your wordlists. Create a base wordlist with a few candidate passwords and use `john` to create many variants of them. Use `john -wordlist:/path/to/your/wordlist -rules:Single -stdout > /path/to/expanded/wordlist` to apply extensive rules (~x1000) `john -wordlist:/path/to/your/wordlist -rules:Wordlist -stdout > /path/to/expanded/wordlist` for a reduced ruleset (~x50).
-- [crunch](https://tools.kali.org/password-attacks/crunch): can generate small wordlists if you have a pattern in mind. For instance, if you know the passwords ends with 1984 and is 6 letters long, use `crunch 6 6 abcdefghijklmnopqrstuvwxyz -t @@1984` will generate the 26 * 26 = 676 passwords aa1984, ab1984, ... up to zz1984. The format is `crunch <min-length> <max-length> <charset> <options>` and we used the templating option. Check out `less /usr/share/crunch/charset.lst` to see the char sets crunch ships with.
-- [CeWL](https://digi.ninja/projects/cewl.php): can generate wordlists if you know a website is related to a password. For instance, run `cewl -d 0 -m 8 https://en.wikipedia.org/wiki/Donald_Trump` if you suspect a picture of Donald Trump contains an encrypted hidden message. The command scrapes the site and extracts strings at least 8 characters long.
+```bash
+# View examples
+ls /examples/
 
+# Create stego examples with various tools
+/examples/create_examples.sh
 
-## Steganography examples
+# Test your skills on the generated files
+check_jpg.sh /examples/stego-files/steghide.jpg
+```
 
-The image contains a sample image and audio file each in different formats:
-- `/examples/ORIGINAL.jpg`
-- `/examples/ORIGINAL.png`
-- `/examples/ORIGINAL.mp3`
-- `/examples/ORIGINAL.wav`
-
-It also contains a script `/examples/create_examples.sh` which you can run to embed a hidden message ("This is a very secret message!") into these files with many different methods.
-After running this script, you find these files in `/examples/stego-files` with their names indicating which tool was used to embed the message.
-You can run the screening scripts to see if they find anything on them or try to break them otherwise.
+---
 
 ## GUI and Containers
 
-By default, no GUI tools can be run in a Docker container as no X11 server is available.
-To run them, you must change that.
-What is required to do so depends on your host machine.
-If you:
-- run on Linux, you probably have X11
-- run on Mac OS, you need Xquartz (`brew install Xquartz`)
-- run on Windows, you have a problem
+### Option 1: VNC (Recommended - No Host Dependencies)
 
-Use X11 forwarding through SSH if you want to go this way. Run `start_ssh` inside the container to start the server, make sure you expose port 22 when starting the container: `docker run -p 127.0.0.1:22:22 ...`, then use `ssh -X ...` when connecting (the script prints the password).
+```bash
+# Start container with VNC port exposed
+docker run -it --rm -p 6901:6901 -v $(pwd)/data:/data stego-toolkit
 
-To not depend on X11, the image comes with a TigerVNC server and noVNC client.
-You can use it to open an HTML5 VNC session with your browser to connect to the containers Xfce desktop. To to that, run `start_vnc.sh` inside the container to start server and client, make sure you expose port 6901 when starting the container `docker run -p 127.0.0.1:6901:6901 ...` and go to `localhost:6901/?password=<the_password>` (the script prints the password).
-
-### Using SSH with X11 forwarding
-
-![animated demo gif - SSH + X11](https://i.imgur.com/aRJtbnP.gif)
-
-Commands in the GIF for copy & paste:
-```
-# in 1st host shell
-docker run -it --rm -p 127.0.0.1:22:22 dominicbreuker/stego-toolkit /bin/bash
-
-# inside container shell
-start_ssh.sh
-
-# in 2nd host shell (use it to launch GUI apps afterwards)
-ssh -X -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@localhost
-```
-
-### Using Browser and VNC
-
-![animated demo gif - Browser + VNC](https://i.imgur.com/3tkw498.gif)
-
-Commands in the GIF for copy & paste:
-```
-# in 1st host shell
-docker run -it --rm -p 127.0.0.1:6901:6901 dominicbreuker/stego-toolkit /bin/bash
-
-# inside container shell
+# Inside container, start VNC
 start_vnc.sh
 
-# in browser, connect with: http://localhost:6901/?password=<password_from_start_vnc>
+# Connect via browser: http://localhost:6901/?password=<printed_password>
 ```
-## Link collection
 
-This is a collection of useful Steganography links:
-- You must be able to spot codes. Check out this [cheat sheet](http://www.ericharshbarger.org/epp/code_sheet.pdf) from Eric Harshbarger, which contains many different codes.
-- Cheat sheet describing workflows, things to look for and common tools: [click](https://pequalsnp-team.github.io/cheatsheet/steganography-101)
-- Forensics CTF guide with lots of ideas for stego challenges: [click](https://trailofbits.github.io/ctf/forensics/)
-- File format descriptions as beautiful posters: [click](https://github.com/corkami/pics/blob/master/binary/README.md)
+### Option 2: SSH with X11 Forwarding
+
+```bash
+# Start container with SSH port exposed
+docker run -it --rm -p 22:22 -v $(pwd)/data:/data stego-toolkit
+
+# Inside container, start SSH server
+start_ssh.sh
+
+# From host (requires X11 server)
+ssh -X -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no stego@localhost
+```
+
+---
+
+## Development
+
+### Building Locally
+
+```bash
+# Build the image
+docker build -t stego-toolkit .
+
+# Run tests
+./tests/smoke_test.sh stego-toolkit
+```
+
+### Running Tests
+
+```bash
+# Run all smoke tests
+./tests/smoke_test.sh stego-toolkit:latest
+
+# Run specific tool tests
+docker run --rm stego-toolkit stegseek --help
+docker run --rm stego-toolkit check_jpg.sh --help
+```
+
+### Project Structure
+
+```
+stego-toolkit/
+├── Dockerfile          # Main Docker image definition
+├── bin/                # Build and run helper scripts
+├── install/            # Tool installation scripts
+├── scripts/            # Analysis and brute-force scripts
+├── examples/           # Sample files for testing
+├── tests/              # Smoke tests
+└── .github/workflows/  # CI/CD configuration
+```
+
+---
+
+## Upgrade Guide (from Original)
+
+If you're coming from the original `dominicbreuker/stego-toolkit`:
+
+### Breaking Changes
+
+1. **Non-root user by default**: Container runs as `stego` user. Use `docker run -u root` if you need root access.
+2. **Python 3 only**: `pybrute.py` and other scripts now require Python 3.
+3. **Script arguments**: Scripts now use long options (`--help`, `--output`, etc.)
+
+### Migration Steps
+
+```bash
+# Old way
+docker run -it dominicbreuker/stego-toolkit /bin/bash
+
+# New way
+docker run -it ghcr.io/consigcody94/stego-toolkit /bin/bash
+
+# If you need root access
+docker run -it -u root ghcr.io/consigcody94/stego-toolkit /bin/bash
+```
+
+### New Features to Try
+
+```bash
+# Stegseek - 1000x faster than stegcracker for steghide files
+stegseek stego.jpg rockyou.txt
+
+# Improved check scripts with colored output
+check_jpg.sh --help
+check_jpg.sh -o ./reports stego.jpg
+
+# Modern hex viewer
+hexyl stego.jpg | head -50
+```
+
+---
+
+## Links & Resources
+
+- [Steganography 101 Cheat Sheet](https://pequalsnp-team.github.io/cheatsheet/steganography-101)
+- [CTF Forensics Guide](https://trailofbits.github.io/ctf/forensics/)
+- [File Format Posters](https://github.com/corkami/pics/blob/master/binary/README.md)
+- [Code Identification Cheat Sheet](http://www.ericharshbarger.org/epp/code_sheet.pdf)
+
+---
+
+## Contributing
+
+Contributions are welcome! Please:
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/new-tool`)
+3. Make your changes
+4. Run the smoke tests (`./tests/smoke_test.sh`)
+5. Submit a pull request
+
+---
+
+## License
+
+MIT License - See [LICENSE](LICENSE) for details.
+
+---
+
+## Credits
+
+- Original project: [DominicBreuker/stego-toolkit](https://github.com/DominicBreuker/stego-toolkit)
+- 2025 Refresh by: [consigcody94](https://github.com/consigcody94)
+- All tool authors - see individual tool repositories for credits
+
+---
 
 ## References
 
-The following example media files are included in this repository:
+Example media files included in this repository:
 - Demo image (JPG, PNG): https://pixabay.com/p-1685092
-- Demo sound file (MP3, WAV): https://upload.wikimedia.org/wikipedia/commons/c/c5/Auphonic-wikimedia-test-stereo.ogg --- By debuglevel (Own work) [CC BY-SA 3.0 (https://creativecommons.org/licenses/by-sa/3.0)], via Wikimedia Commons
+- Demo sound file (MP3, WAV): [Wikimedia Commons](https://upload.wikimedia.org/wikipedia/commons/c/c5/Auphonic-wikimedia-test-stereo.ogg) - CC BY-SA 3.0

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 # =============================================================================
-# build.sh - Build the stego-toolkit Docker image
+# build.sh - Build stego-toolkit Docker images
 # Part of stego-toolkit (2025 refresh)
+# =============================================================================
+# Usage:
+#   ./build.sh              # Build full image (default)
+#   ./build.sh --cli        # Build CLI-only (lightweight)
+#   ./build.sh --gpu        # Build GPU-accelerated image
+#   ./build.sh --all        # Build all variants
 # =============================================================================
 set -euo pipefail
 
@@ -10,17 +16,170 @@ source "${SCRIPT_DIR}/shared.sh"
 
 PROJECT_ROOT="$(abspath "${SCRIPT_DIR}/..")"
 
-echo "Building stego-toolkit Docker image..."
-echo "Image name: ${IMAGE_NAME}"
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Build stego-toolkit Docker images.
+
+Options:
+    -h, --help      Show this help message
+    --full          Build full image with GUI support (default)
+    --cli           Build CLI-only lightweight image
+    --gpu           Build GPU-accelerated image (requires NVIDIA)
+    --all           Build all image variants
+    --no-cache      Build without using cache
+
+Image Variants:
+    full    ~2.5GB  Full image with GUI tools (VNC, X11)
+    cli     ~1.5GB  CLI-only, no GUI dependencies
+    gpu     ~8GB    GPU-accelerated with CUDA, hashcat, PyTorch
+
+Examples:
+    $(basename "$0")              # Build full image
+    $(basename "$0") --cli        # Build lightweight CLI image
+    $(basename "$0") --gpu        # Build GPU image
+    $(basename "$0") --all        # Build all variants
+EOF
+    exit 0
+}
+
+build_image() {
+    local variant="$1"
+    local dockerfile="$2"
+    local tag="$3"
+
+    echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  Building: stego-toolkit:${tag}${NC}"
+    echo -e "${BLUE}  Dockerfile: ${dockerfile}${NC}"
+    echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    local cache_arg=""
+    if [[ "${NO_CACHE:-0}" == "1" ]]; then
+        cache_arg="--no-cache"
+    fi
+
+    if docker build \
+        -f "${PROJECT_ROOT}/${dockerfile}" \
+        -t "stego-toolkit:${tag}" \
+        ${cache_arg} \
+        "${PROJECT_ROOT}"; then
+        echo ""
+        echo -e "${GREEN}[SUCCESS]${NC} stego-toolkit:${tag} built successfully"
+    else
+        echo ""
+        echo -e "${RED}[FAILED]${NC} Failed to build stego-toolkit:${tag}"
+        return 1
+    fi
+}
+
+# Parse arguments
+BUILD_FULL=0
+BUILD_CLI=0
+BUILD_GPU=0
+NO_CACHE=0
+
+if [[ $# -eq 0 ]]; then
+    BUILD_FULL=1
+fi
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        --full)
+            BUILD_FULL=1
+            shift
+            ;;
+        --cli)
+            BUILD_CLI=1
+            shift
+            ;;
+        --gpu)
+            BUILD_GPU=1
+            shift
+            ;;
+        --all)
+            BUILD_FULL=1
+            BUILD_CLI=1
+            BUILD_GPU=1
+            shift
+            ;;
+        --no-cache)
+            NO_CACHE=1
+            shift
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            usage
+            ;;
+    esac
+done
+
+echo ""
+echo -e "${BLUE}Stego-Toolkit Docker Image Builder${NC}"
 echo "Project root: ${PROJECT_ROOT}"
 echo ""
 
-docker build \
-    -f "${PROJECT_ROOT}/Dockerfile" \
-    -t "${IMAGE_NAME}" \
-    "${PROJECT_ROOT}"
+# Build requested variants
+BUILT=0
+FAILED=0
 
+if [[ $BUILD_FULL -eq 1 ]]; then
+    if build_image "full" "Dockerfile" "latest"; then
+        ((BUILT++))
+    else
+        ((FAILED++))
+    fi
+    echo ""
+fi
+
+if [[ $BUILD_CLI -eq 1 ]]; then
+    if build_image "cli" "Dockerfile.cli" "cli"; then
+        ((BUILT++))
+    else
+        ((FAILED++))
+    fi
+    echo ""
+fi
+
+if [[ $BUILD_GPU -eq 1 ]]; then
+    echo -e "${YELLOW}Note: GPU image requires NVIDIA drivers and nvidia-container-toolkit${NC}"
+    if build_image "gpu" "Dockerfile.gpu" "gpu"; then
+        ((BUILT++))
+    else
+        ((FAILED++))
+    fi
+    echo ""
+fi
+
+# Summary
 echo ""
-echo "Build complete!"
-echo "Run with: ${SCRIPT_DIR}/run.sh"
-echo "Or: docker run -it --rm -v \$(pwd)/data:/data ${IMAGE_NAME}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}  Build Summary${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "  ${GREEN}Built: ${BUILT}${NC}"
+echo -e "  ${RED}Failed: ${FAILED}${NC}"
+echo ""
+
+if [[ $BUILD_FULL -eq 1 ]]; then
+    echo "Run full image:  docker run -it --rm -v \$(pwd)/data:/data stego-toolkit:latest"
+fi
+if [[ $BUILD_CLI -eq 1 ]]; then
+    echo "Run CLI image:   docker run -it --rm -v \$(pwd)/data:/data stego-toolkit:cli"
+fi
+if [[ $BUILD_GPU -eq 1 ]]; then
+    echo "Run GPU image:   docker run --gpus all -it --rm -v \$(pwd)/data:/data stego-toolkit:gpu"
+fi
+echo ""
+
+exit $FAILED

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
+# =============================================================================
+# build.sh - Build the stego-toolkit Docker image
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
+set -euo pipefail
 
-script="$0"
-FOLDER="$(dirname $script)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/shared.sh"
 
-source $FOLDER/shared.sh
-PROJECT_ROOT="$(abspath $FOLDER/..)"
+PROJECT_ROOT="$(abspath "${SCRIPT_DIR}/..")"
 
-echo "Building Docker image now..."
+echo "Building stego-toolkit Docker image..."
+echo "Image name: ${IMAGE_NAME}"
+echo "Project root: ${PROJECT_ROOT}"
+echo ""
 
-docker build -f $PROJECT_ROOT/Dockerfile \
-             -t $IMAGE_NAME \
-             $PROJECT_ROOT
+docker build \
+    -f "${PROJECT_ROOT}/Dockerfile" \
+    -t "${IMAGE_NAME}" \
+    "${PROJECT_ROOT}"
+
+echo ""
+echo "Build complete!"
+echo "Run with: ${SCRIPT_DIR}/run.sh"
+echo "Or: docker run -it --rm -v \$(pwd)/data:/data ${IMAGE_NAME}"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,20 +1,36 @@
 #!/bin/bash
+# =============================================================================
+# run.sh - Run the stego-toolkit Docker container
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
+set -euo pipefail
 
-script="$0"
-FOLDER="$(dirname $script)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/shared.sh"
 
-source $FOLDER/shared.sh
-PROJECT_ROOT="$(abspath $FOLDER/..)"
+PROJECT_ROOT="$(abspath "${SCRIPT_DIR}/..")"
 
-echo "Starting container now..."
+echo "Starting stego-toolkit container..."
+echo "Image: ${IMAGE_NAME}"
+echo ""
+echo "Mounted volumes:"
+echo "  - ${PROJECT_ROOT}/data -> /data"
+echo "  - ${PROJECT_ROOT}/scripts -> /opt/scripts"
+echo "  - ${PROJECT_ROOT}/examples -> /examples"
+echo ""
+echo "Exposed ports:"
+echo "  - 22 (SSH with X11 forwarding)"
+echo "  - 5901 (VNC)"
+echo "  - 6901 (noVNC web interface)"
+echo ""
+
 docker run -it \
-           --rm \
-           -p 127.0.0.1:22:22 \
-           -p 127.0.0.1:5901:5901 \
-           -p 127.0.0.1:6901:6901 \
-           -v $PROJECT_ROOT/data:/data \
-           -v $PROJECT_ROOT/scripts:/opt/scripts \
-           -v $PROJECT_ROOT/examples:/examples \
-           -v $PROJECT_ROOT/install_dev:/install_dev \
-           $IMAGE_NAME \
-           /bin/bash
+    --rm \
+    -p 127.0.0.1:22:22 \
+    -p 127.0.0.1:5901:5901 \
+    -p 127.0.0.1:6901:6901 \
+    -v "${PROJECT_ROOT}/data:/data" \
+    -v "${PROJECT_ROOT}/scripts:/opt/scripts" \
+    -v "${PROJECT_ROOT}/examples:/examples" \
+    "${IMAGE_NAME}" \
+    /bin/bash

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # =============================================================================
-# run.sh - Run the stego-toolkit Docker container
+# run.sh - Run stego-toolkit Docker containers
 # Part of stego-toolkit (2025 refresh)
+# =============================================================================
+# Usage:
+#   ./run.sh              # Run full image (default)
+#   ./run.sh --cli        # Run CLI-only image
+#   ./run.sh --gpu        # Run GPU-accelerated image
 # =============================================================================
 set -euo pipefail
 
@@ -10,27 +15,125 @@ source "${SCRIPT_DIR}/shared.sh"
 
 PROJECT_ROOT="$(abspath "${SCRIPT_DIR}/..")"
 
-echo "Starting stego-toolkit container..."
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] [-- COMMAND]
+
+Run stego-toolkit Docker container.
+
+Options:
+    -h, --help      Show this help message
+    --full          Run full image with GUI support (default)
+    --cli           Run CLI-only lightweight image
+    --gpu           Run GPU-accelerated image (requires NVIDIA)
+    --root          Run as root user instead of stego
+    --no-mount      Don't mount local directories
+
+Examples:
+    $(basename "$0")                          # Interactive shell in full image
+    $(basename "$0") --cli                    # Interactive shell in CLI image
+    $(basename "$0") --gpu                    # Interactive shell with GPU
+    $(basename "$0") -- check_jpg.sh test.jpg # Run specific command
+    $(basename "$0") --cli -- stegseek img.jpg wordlist.txt
+EOF
+    exit 0
+}
+
+# Defaults
+IMAGE_TAG="latest"
+RUN_AS_ROOT=0
+MOUNT_DIRS=1
+GPU_MODE=0
+
+# Parse arguments
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        --full)
+            IMAGE_TAG="latest"
+            shift
+            ;;
+        --cli)
+            IMAGE_TAG="cli"
+            shift
+            ;;
+        --gpu)
+            IMAGE_TAG="gpu"
+            GPU_MODE=1
+            shift
+            ;;
+        --root)
+            RUN_AS_ROOT=1
+            shift
+            ;;
+        --no-mount)
+            MOUNT_DIRS=0
+            shift
+            ;;
+        --)
+            shift
+            EXTRA_ARGS=("$@")
+            break
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+IMAGE_NAME="stego-toolkit:${IMAGE_TAG}"
+
+echo -e "${BLUE}Starting stego-toolkit container...${NC}"
 echo "Image: ${IMAGE_NAME}"
 echo ""
-echo "Mounted volumes:"
-echo "  - ${PROJECT_ROOT}/data -> /data"
-echo "  - ${PROJECT_ROOT}/scripts -> /opt/scripts"
-echo "  - ${PROJECT_ROOT}/examples -> /examples"
-echo ""
-echo "Exposed ports:"
-echo "  - 22 (SSH with X11 forwarding)"
-echo "  - 5901 (VNC)"
-echo "  - 6901 (noVNC web interface)"
+
+# Build docker run command
+DOCKER_ARGS=("-it" "--rm")
+
+# GPU support
+if [[ $GPU_MODE -eq 1 ]]; then
+    DOCKER_ARGS+=("--gpus" "all")
+    echo -e "${YELLOW}GPU mode enabled${NC}"
+fi
+
+# Port mappings (only for full image)
+if [[ "$IMAGE_TAG" == "latest" ]]; then
+    DOCKER_ARGS+=("-p" "127.0.0.1:22:22")
+    DOCKER_ARGS+=("-p" "127.0.0.1:5901:5901")
+    DOCKER_ARGS+=("-p" "127.0.0.1:6901:6901")
+    echo "Exposed ports: 22 (SSH), 5901 (VNC), 6901 (noVNC)"
+fi
+
+# Volume mounts
+if [[ $MOUNT_DIRS -eq 1 ]]; then
+    DOCKER_ARGS+=("-v" "${PROJECT_ROOT}/data:/data")
+    DOCKER_ARGS+=("-v" "${PROJECT_ROOT}/scripts:/opt/scripts")
+    DOCKER_ARGS+=("-v" "${PROJECT_ROOT}/examples:/examples")
+    echo "Mounted: data/, scripts/, examples/"
+fi
+
+# User
+if [[ $RUN_AS_ROOT -eq 1 ]]; then
+    DOCKER_ARGS+=("-u" "root")
+    echo -e "${YELLOW}Running as root${NC}"
+fi
+
 echo ""
 
-docker run -it \
-    --rm \
-    -p 127.0.0.1:22:22 \
-    -p 127.0.0.1:5901:5901 \
-    -p 127.0.0.1:6901:6901 \
-    -v "${PROJECT_ROOT}/data:/data" \
-    -v "${PROJECT_ROOT}/scripts:/opt/scripts" \
-    -v "${PROJECT_ROOT}/examples:/examples" \
-    "${IMAGE_NAME}" \
-    /bin/bash
+# Run container
+if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
+    docker run "${DOCKER_ARGS[@]}" "${IMAGE_NAME}" "${EXTRA_ARGS[@]}"
+else
+    docker run "${DOCKER_ARGS[@]}" "${IMAGE_NAME}" /bin/bash
+fi

--- a/bin/shared.sh
+++ b/bin/shared.sh
@@ -1,3 +1,24 @@
-export IMAGE_NAME=local/stego:latest
+#!/bin/bash
+# =============================================================================
+# shared.sh - Shared configuration for build/run scripts
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
 
-function abspath() { pushd . > /dev/null; if [ -d "$1" ]; then cd "$1"; dirs -l +0; else cd "`dirname \"$1\"`"; cur_dir=`dirs -l +0`; if [ "$cur_dir" == "/" ]; then echo "$cur_dir`basename \"$1\"`"; else echo "$cur_dir/`basename \"$1\"`"; fi; fi; popd > /dev/null; }
+export IMAGE_NAME="${STEGO_IMAGE_NAME:-stego-toolkit:latest}"
+
+# Get the absolute path of a file or directory
+abspath() {
+    if [[ -d "$1" ]]; then
+        (cd "$1" && pwd)
+    elif [[ -f "$1" ]]; then
+        if [[ "$1" == /* ]]; then
+            echo "$1"
+        elif [[ "$1" == */* ]]; then
+            echo "$(cd "${1%/*}" && pwd)/${1##*/}"
+        else
+            echo "$(pwd)/$1"
+        fi
+    else
+        echo "$1"
+    fi
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+# =============================================================================
+# docker-compose.yml - Easy startup for stego-toolkit
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
+#
+# Usage:
+#   docker compose up -d        # Start in background
+#   docker compose exec stego bash  # Get shell access
+#   docker compose down         # Stop and remove
+#
+# =============================================================================
+
+services:
+  stego:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: stego-toolkit:latest
+    container_name: stego-toolkit
+    hostname: stego
+    stdin_open: true
+    tty: true
+
+    # Mount your data directory
+    volumes:
+      - ./data:/data
+      - ./examples:/examples
+
+    # Expose ports for GUI access
+    ports:
+      - "127.0.0.1:22:22"      # SSH with X11 forwarding
+      - "127.0.0.1:5901:5901"  # VNC
+      - "127.0.0.1:6901:6901"  # noVNC (web browser)
+
+    # Security options
+    security_opt:
+      - no-new-privileges:true
+
+    # Resource limits (optional - uncomment to enable)
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '4'
+    #       memory: 4G
+
+    # Health check
+    healthcheck:
+      test: ["CMD", "which", "steghide"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+# Optional: Create named volumes for persistent data
+# volumes:
+#   stego-data:

--- a/install/hexyl.sh
+++ b/install/hexyl.sh
@@ -1,6 +1,46 @@
-#!/bin/sh
-
+#!/bin/bash
+# =============================================================================
+# Install hexyl - A modern hex viewer with colored output
+# https://github.com/sharkdp/hexyl
+# =============================================================================
 set -e
 
-wget -O /tmp/hexyl.dev https://github.com/sharkdp/hexyl/releases/download/v0.4.0/hexyl_0.4.0_amd64.deb
-dpkg -i /tmp/hexyl
+echo "Installing hexyl..."
+
+# Try to install from apt first (available in newer Debian/Ubuntu)
+if apt-get install -y -qq hexyl 2>/dev/null; then
+    echo "hexyl installed from apt"
+else
+    # Fall back to downloading from GitHub releases
+    echo "Installing hexyl from GitHub releases..."
+    HEXYL_VERSION="0.14.0"
+    ARCH=$(dpkg --print-architecture)
+
+    case $ARCH in
+        amd64)
+            HEXYL_ARCH="x86_64"
+            ;;
+        arm64)
+            HEXYL_ARCH="aarch64"
+            ;;
+        *)
+            echo "Unsupported architecture: $ARCH"
+            exit 1
+            ;;
+    esac
+
+    HEXYL_URL="https://github.com/sharkdp/hexyl/releases/download/v${HEXYL_VERSION}/hexyl-v${HEXYL_VERSION}-${HEXYL_ARCH}-unknown-linux-gnu.tar.gz"
+
+    cd /tmp
+    wget -q "${HEXYL_URL}" -O hexyl.tar.gz
+    tar -xzf hexyl.tar.gz
+    mv hexyl-*/hexyl /usr/local/bin/
+    rm -rf hexyl.tar.gz hexyl-*
+fi
+
+# Verify installation
+if command -v hexyl &> /dev/null; then
+    echo "hexyl installed successfully: $(hexyl --version 2>&1)"
+else
+    echo "Warning: hexyl installation may have failed"
+fi

--- a/install/jsteg.sh
+++ b/install/jsteg.sh
@@ -1,10 +1,38 @@
 #!/bin/bash
-
+# =============================================================================
+# Install jsteg - LSB steganography tool for JPEG images
+# https://github.com/lukechampine/jsteg
+# =============================================================================
 set -e
 
-# Download
-wget -O /usr/bin/jsteg https://github.com/lukechampine/jsteg/releases/download/v0.1.0/jsteg-linux-amd64
-chmod +x /usr/bin/jsteg
+echo "Installing jsteg..."
 
-wget -O /usr/bin/slink https://github.com/lukechampine/jsteg/releases/download/v0.2.0/slink-linux-amd64
-chmod +x /usr/bin/slink
+ARCH=$(dpkg --print-architecture)
+
+case $ARCH in
+    amd64)
+        JSTEG_ARCH="amd64"
+        ;;
+    arm64)
+        JSTEG_ARCH="arm64"
+        ;;
+    *)
+        echo "Warning: jsteg may not support architecture: $ARCH"
+        JSTEG_ARCH="amd64"
+        ;;
+esac
+
+# Install jsteg
+wget -q -O /usr/local/bin/jsteg "https://github.com/lukechampine/jsteg/releases/download/v0.3.0/jsteg-linux-${JSTEG_ARCH}"
+chmod +x /usr/local/bin/jsteg
+
+# Install slink (related tool for PNG)
+wget -q -O /usr/local/bin/slink "https://github.com/lukechampine/jsteg/releases/download/v0.3.0/slink-linux-${JSTEG_ARCH}"
+chmod +x /usr/local/bin/slink
+
+# Verify installation
+if command -v jsteg &> /dev/null; then
+    echo "jsteg installed successfully"
+else
+    echo "Warning: jsteg installation may have failed"
+fi

--- a/install/openstego.sh
+++ b/install/openstego.sh
@@ -1,16 +1,33 @@
 #!/bin/bash
-
+# =============================================================================
+# Install OpenStego - Open source steganography solution
+# https://github.com/syvaidya/openstego
+# =============================================================================
 set -e
 
-# Download
-wget -O /tmp/openstego.deb https://github.com/syvaidya/openstego/releases/download/openstego-0.7.1/openstego_0.7.1-1_amd64.deb
+echo "Installing OpenStego..."
 
-# Install
-dpkg -i /tmp/openstego.deb || apt-get install -f -y
-rm /tmp/openstego.deb
+OPENSTEGO_VERSION="0.8.6"
+OPENSTEGO_URL="https://github.com/syvaidya/openstego/releases/download/openstego-${OPENSTEGO_VERSION}/openstego_${OPENSTEGO_VERSION}-1_all.deb"
 
-cat << EOF > /usr/bin/openstego
-#!/bin/sh
-java -jar /usr/share/openstego/lib/openstego.jar \$@
+cd /tmp
+wget -q "${OPENSTEGO_URL}" -O openstego.deb
+
+# Install dependencies and package
+apt-get update -qq
+dpkg -i openstego.deb || apt-get install -f -y -qq
+rm -f openstego.deb
+
+# Create wrapper script
+cat << 'EOF' > /usr/local/bin/openstego
+#!/bin/bash
+java -jar /usr/share/openstego/lib/openstego.jar "$@"
 EOF
-chmod +x /usr/bin/openstego
+chmod +x /usr/local/bin/openstego
+
+# Verify installation
+if [ -f /usr/share/openstego/lib/openstego.jar ]; then
+    echo "OpenStego installed successfully (version ${OPENSTEGO_VERSION})"
+else
+    echo "Warning: OpenStego installation may have failed"
+fi

--- a/install/stegano.sh
+++ b/install/stegano.sh
@@ -1,42 +1,19 @@
 #!/bin/bash
-
+# =============================================================================
+# Install Stegano - Python steganography module
+# https://github.com/cedricbonhomme/Stegano
+# =============================================================================
 set -e
 
-# Download
-git clone https://github.com/cedricbonhomme/Stegano.git /opt/Stegano
-cd /opt/Stegano
-git checkout v0.8.2
+echo "Installing Stegano..."
 
-# Install
-pip3 install -r /opt/Stegano/requirements.txt
-cp /opt/Stegano/bin/* /opt/Stegano/
+# Install via pip (modern approach, provides CLI tools automatically)
+pip3 install --break-system-packages --no-cache-dir stegano
 
-cat << EOF > /usr/bin/stegano-lsb
-#!/bin/sh
-python3 /opt/Stegano/stegano-lsb \$@
-EOF
-chmod +x /usr/bin/stegano-lsb
-
-cat << EOF > /usr/bin/stegano-lsb-set
-#!/bin/sh
-python3 /opt/Stegano/stegano-lsb-set \$@
-EOF
-chmod +x /usr/bin/stegano-lsb-set
-
-cat << EOF > /usr/bin/stegano-red
-#!/bin/sh
-python3 /opt/Stegano/stegano-red \$@
-EOF
-chmod +x /usr/bin/stegano-red
-
-cat << EOF > /usr/bin/stegano-steganalysis-parity
-#!/bin/sh
-python3 /opt/Stegano/stegano-steganalysis-parity \$@
-EOF
-chmod +x /usr/bin/stegano-steganalysis-parity
-
-cat << EOF > /usr/bin/stegano-steganalysis-statistics
-#!/bin/sh
-python3 /opt/Stegano/stegano-steganalysis-statistics \$@
-EOF
-chmod +x /usr/bin/stegano-steganalysis-statistics
+# Verify installation
+if command -v stegano-lsb &> /dev/null; then
+    echo "Stegano installed successfully"
+    echo "Available commands: stegano-lsb, stegano-lsb-set, stegano-red"
+else
+    echo "Warning: Stegano installation may have failed"
+fi

--- a/install/stegcracker.sh
+++ b/install/stegcracker.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# =============================================================================
+# Install stegcracker - Steganography brute-force utility
+# https://github.com/Paradoxis/StegCracker
+# =============================================================================
+set -e
+
+echo "Installing stegcracker..."
+
+# Install via pip
+pip3 install --break-system-packages --no-cache-dir stegcracker
+
+# Verify installation
+if command -v stegcracker &> /dev/null; then
+    echo "stegcracker installed successfully: $(stegcracker --version 2>&1 | head -1 || echo 'version check unavailable')"
+else
+    echo "Warning: stegcracker installation may have failed"
+fi

--- a/install/stegoVeritas.sh
+++ b/install/stegoVeritas.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
-
+# =============================================================================
+# Install stegoveritas - Multi-tool stego analyzer
+# https://github.com/bannsec/stegoVeritas
+# =============================================================================
 set -e
 
-pip3 install stegoveritas
-stegoveritas_install_deps
+echo "Installing stegoveritas..."
+
+# Install via pip (already done in Dockerfile, but keeping for standalone use)
+pip3 install --break-system-packages --no-cache-dir stegoveritas
+
+# Install dependencies (may require user interaction in some cases)
+echo "Installing stegoveritas dependencies..."
+stegoveritas_install_deps || true
+
+# Verify installation
+if command -v stegoveritas &> /dev/null; then
+    echo "stegoveritas installed successfully"
+else
+    echo "Warning: stegoveritas installation may have failed"
+fi

--- a/install/stegseek.sh
+++ b/install/stegseek.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# =============================================================================
+# Install stegseek - Lightning fast steghide cracker
+# https://github.com/RickdeJager/stegseek
+# =============================================================================
+set -e
+
+echo "Installing stegseek..."
+
+# Get the latest release version
+STEGSEEK_VERSION="0.6"
+STEGSEEK_DEB="stegseek_${STEGSEEK_VERSION}-1.deb"
+STEGSEEK_URL="https://github.com/RickdeJager/stegseek/releases/download/v${STEGSEEK_VERSION}/${STEGSEEK_DEB}"
+
+# Download and install the .deb package
+cd /tmp
+wget -q "${STEGSEEK_URL}" -O "${STEGSEEK_DEB}"
+apt-get update -qq
+apt-get install -y -qq "./${STEGSEEK_DEB}"
+rm -f "${STEGSEEK_DEB}"
+
+# Verify installation
+if command -v stegseek &> /dev/null; then
+    echo "stegseek installed successfully: $(stegseek --version 2>&1 | head -1)"
+else
+    echo "Warning: stegseek installation may have failed"
+fi

--- a/install/stegsolve.sh
+++ b/install/stegsolve.sh
@@ -1,11 +1,37 @@
 #!/bin/bash
-
+# =============================================================================
+# Install Stegsolve - Image analysis tool for steganography
+# http://www.caesum.com/handbook/stego.htm
+# =============================================================================
 set -e
 
-wget -O /opt/Stegsolve.jar http://www.caesum.com/handbook/Stegsolve.jar
+echo "Installing Stegsolve..."
 
-cat << EOF > /usr/bin/stegsolve
-#!/bin/sh
-java -jar /opt/Stegsolve.jar \$@
+# Create installation directory
+mkdir -p /opt/stegsolve
+
+# Download Stegsolve JAR
+# Note: The original source may be unavailable, using mirror
+STEGSOLVE_URL="http://www.caesum.com/handbook/Stegsolve.jar"
+MIRROR_URL="https://github.com/Giotino/stegsolve/releases/download/v1.4/StegSolve-1.4.jar"
+
+if wget -q --spider "${STEGSOLVE_URL}" 2>/dev/null; then
+    wget -q -O /opt/stegsolve/Stegsolve.jar "${STEGSOLVE_URL}"
+else
+    echo "Original source unavailable, trying mirror..."
+    wget -q -O /opt/stegsolve/Stegsolve.jar "${MIRROR_URL}"
+fi
+
+# Create wrapper script
+cat << 'EOF' > /usr/local/bin/stegsolve
+#!/bin/bash
+java -jar /opt/stegsolve/Stegsolve.jar "$@"
 EOF
-chmod +x /usr/bin/stegsolve
+chmod +x /usr/local/bin/stegsolve
+
+# Verify installation
+if [ -f /opt/stegsolve/Stegsolve.jar ]; then
+    echo "Stegsolve installed successfully"
+else
+    echo "Warning: Stegsolve installation may have failed"
+fi

--- a/install/zsteg.sh
+++ b/install/zsteg.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
-
+# =============================================================================
+# Install zsteg - PNG/BMP LSB steganography detector
+# https://github.com/zed-0xff/zsteg
+# =============================================================================
 set -e
 
-apt-get install -y ruby-dev
-gem install rake
-gem install zsteg
+echo "Installing zsteg..."
+
+# Install via gem (already done in Dockerfile, but keeping for standalone use)
+gem install zsteg --no-document
+
+# Verify installation
+if command -v zsteg &> /dev/null; then
+    echo "zsteg installed successfully: $(zsteg --version 2>&1 || echo 'version check unavailable')"
+else
+    echo "Warning: zsteg installation may have failed"
+fi

--- a/mcp/stego-mcp-server.py
+++ b/mcp/stego-mcp-server.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""
+Stego-Toolkit MCP Server
+========================
+Model Context Protocol server for steganography analysis.
+
+Compatible with:
+- Claude Code / Claude Desktop
+- Gemini CLI
+- OpenAI Codex CLI
+- Any MCP-compatible AI assistant
+
+Usage:
+    python stego-mcp-server.py
+
+Configuration (claude_desktop_config.json):
+    {
+        "mcpServers": {
+            "stego-toolkit": {
+                "command": "docker",
+                "args": ["run", "-i", "--rm", "-v", "/path/to/data:/data", "stego-toolkit:cli", "python3", "/opt/mcp/stego-mcp-server.py"]
+            }
+        }
+    }
+"""
+
+import asyncio
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+
+# MCP Protocol Implementation
+class MCPServer:
+    """Simple MCP server implementation for stego-toolkit."""
+
+    def __init__(self):
+        self.tools = {
+            "analyze_image": self.analyze_image,
+            "analyze_audio": self.analyze_audio,
+            "extract_steghide": self.extract_steghide,
+            "crack_steghide": self.crack_steghide,
+            "detect_lsb": self.detect_lsb,
+            "extract_strings": self.extract_strings,
+            "check_metadata": self.check_metadata,
+            "binwalk_scan": self.binwalk_scan,
+            "list_tools": self.list_tools,
+        }
+
+    async def handle_request(self, request: dict) -> dict:
+        """Handle incoming MCP request."""
+        method = request.get("method", "")
+        params = request.get("params", {})
+        request_id = request.get("id")
+
+        try:
+            if method == "initialize":
+                return self._initialize_response(request_id)
+            elif method == "tools/list":
+                return self._list_tools_response(request_id)
+            elif method == "tools/call":
+                return await self._call_tool(request_id, params)
+            elif method == "resources/list":
+                return self._list_resources_response(request_id)
+            else:
+                return self._error_response(request_id, -32601, f"Method not found: {method}")
+        except Exception as e:
+            return self._error_response(request_id, -32603, str(e))
+
+    def _initialize_response(self, request_id: Any) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {
+                    "tools": {},
+                    "resources": {},
+                },
+                "serverInfo": {
+                    "name": "stego-toolkit",
+                    "version": "2.0.0",
+                },
+            },
+        }
+
+    def _list_tools_response(self, request_id: Any) -> dict:
+        tools = [
+            {
+                "name": "analyze_image",
+                "description": "Comprehensive steganography analysis of an image file (JPG, PNG, BMP, GIF). Runs multiple detection tools including exiftool, binwalk, strings, zsteg, and stegoveritas.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the image file to analyze",
+                        },
+                        "thorough": {
+                            "type": "boolean",
+                            "description": "Run thorough analysis (slower but more comprehensive)",
+                            "default": False,
+                        },
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "analyze_audio",
+                "description": "Analyze audio file for hidden data (MP3, WAV, FLAC). Checks metadata, spectrograms, and common audio stego techniques.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the audio file to analyze",
+                        },
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "extract_steghide",
+                "description": "Extract hidden data from a file using steghide with a known password.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the stego file",
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for extraction (empty string for no password)",
+                            "default": "",
+                        },
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "crack_steghide",
+                "description": "Attempt to crack steghide password using stegseek (very fast) with a wordlist.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the stego file",
+                        },
+                        "wordlist": {
+                            "type": "string",
+                            "description": "Path to wordlist file (default: rockyou.txt)",
+                            "default": "/usr/share/wordlists/rockyou.txt",
+                        },
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "detect_lsb",
+                "description": "Detect LSB (Least Significant Bit) steganography in PNG/BMP images using zsteg.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the image file",
+                        },
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "extract_strings",
+                "description": "Extract readable strings from a file.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the file",
+                        },
+                        "min_length": {
+                            "type": "integer",
+                            "description": "Minimum string length",
+                            "default": 4,
+                        },
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "check_metadata",
+                "description": "Extract and display file metadata using exiftool.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the file",
+                        },
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "binwalk_scan",
+                "description": "Scan file for embedded files and data using binwalk.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the file",
+                        },
+                        "extract": {
+                            "type": "boolean",
+                            "description": "Extract embedded files",
+                            "default": False,
+                        },
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "list_tools",
+                "description": "List all available steganography tools in the toolkit.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                },
+            },
+        ]
+
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"tools": tools},
+        }
+
+    def _list_resources_response(self, request_id: Any) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"resources": []},
+        }
+
+    async def _call_tool(self, request_id: Any, params: dict) -> dict:
+        tool_name = params.get("name")
+        arguments = params.get("arguments", {})
+
+        if tool_name not in self.tools:
+            return self._error_response(request_id, -32602, f"Unknown tool: {tool_name}")
+
+        try:
+            result = await self.tools[tool_name](**arguments)
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "content": [{"type": "text", "text": result}],
+                },
+            }
+        except Exception as e:
+            return self._error_response(request_id, -32603, f"Tool error: {str(e)}")
+
+    def _error_response(self, request_id: Any, code: int, message: str) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+
+    # Tool implementations
+    async def analyze_image(self, file_path: str, thorough: bool = False) -> str:
+        """Comprehensive image analysis."""
+        results = []
+        results.append(f"=== Stego Analysis: {file_path} ===\n")
+
+        # File type
+        results.append("--- File Type ---")
+        results.append(self._run_command(["file", file_path]))
+
+        # Metadata
+        results.append("\n--- Metadata (exiftool) ---")
+        results.append(self._run_command(["exiftool", file_path]))
+
+        # Binwalk
+        results.append("\n--- Embedded Files (binwalk) ---")
+        results.append(self._run_command(["binwalk", file_path]))
+
+        # Strings (brief)
+        results.append("\n--- Strings (first 20) ---")
+        strings_out = self._run_command(["strings", file_path])
+        results.append("\n".join(strings_out.split("\n")[:20]))
+
+        # LSB detection for PNG/BMP
+        if file_path.lower().endswith((".png", ".bmp")):
+            results.append("\n--- LSB Analysis (zsteg) ---")
+            results.append(self._run_command(["zsteg", "-a", file_path]))
+
+        # Steghide check (empty password)
+        if file_path.lower().endswith((".jpg", ".jpeg", ".bmp")):
+            results.append("\n--- Steghide (empty password) ---")
+            results.append(self._run_command(["steghide", "info", "-sf", file_path, "-p", ""]))
+
+            # Stegseek seed detection
+            results.append("\n--- Stegseek Seed Detection ---")
+            results.append(self._run_command(["stegseek", "--seed", file_path]))
+
+        if thorough:
+            results.append("\n--- StegOveritas (thorough) ---")
+            with tempfile.TemporaryDirectory() as tmpdir:
+                self._run_command(["stegoveritas", file_path, "-out", tmpdir, "-meta", "-imageTransform"])
+                results.append(f"Results saved to: {tmpdir}")
+
+        return "\n".join(results)
+
+    async def analyze_audio(self, file_path: str) -> str:
+        """Analyze audio file."""
+        results = []
+        results.append(f"=== Audio Analysis: {file_path} ===\n")
+
+        results.append("--- File Type ---")
+        results.append(self._run_command(["file", file_path]))
+
+        results.append("\n--- Metadata (exiftool) ---")
+        results.append(self._run_command(["exiftool", file_path]))
+
+        results.append("\n--- Media Info ---")
+        results.append(self._run_command(["mediainfo", file_path]))
+
+        results.append("\n--- FFmpeg Info ---")
+        results.append(self._run_command(["ffmpeg", "-i", file_path, "-f", "null", "-"], stderr=True))
+
+        results.append("\n--- Strings (first 20) ---")
+        strings_out = self._run_command(["strings", file_path])
+        results.append("\n".join(strings_out.split("\n")[:20]))
+
+        return "\n".join(results)
+
+    async def extract_steghide(self, file_path: str, password: str = "") -> str:
+        """Extract with steghide."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".out") as tmp:
+            result = self._run_command([
+                "steghide", "extract", "-sf", file_path, "-p", password, "-xf", tmp.name, "-f"
+            ])
+            if os.path.exists(tmp.name) and os.path.getsize(tmp.name) > 0:
+                with open(tmp.name, "rb") as f:
+                    data = f.read()
+                try:
+                    content = data.decode("utf-8")
+                    return f"Extracted data:\n{content}"
+                except UnicodeDecodeError:
+                    return f"Extracted binary data ({len(data)} bytes): {data[:100]}..."
+            return f"Extraction result:\n{result}"
+
+    async def crack_steghide(self, file_path: str, wordlist: str = "/usr/share/wordlists/rockyou.txt") -> str:
+        """Crack steghide with stegseek."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".out") as tmp:
+            result = self._run_command(["stegseek", file_path, wordlist, "-xf", tmp.name])
+            if "found" in result.lower() or os.path.getsize(tmp.name) > 0:
+                with open(tmp.name, "rb") as f:
+                    data = f.read()
+                try:
+                    content = data.decode("utf-8")
+                    return f"Password cracked!\n{result}\n\nExtracted data:\n{content}"
+                except UnicodeDecodeError:
+                    return f"Password cracked!\n{result}\n\nExtracted binary data ({len(data)} bytes)"
+            return f"Crack attempt result:\n{result}"
+
+    async def detect_lsb(self, file_path: str) -> str:
+        """Detect LSB steganography."""
+        return self._run_command(["zsteg", "-a", file_path])
+
+    async def extract_strings(self, file_path: str, min_length: int = 4) -> str:
+        """Extract strings from file."""
+        return self._run_command(["strings", f"-n{min_length}", file_path])
+
+    async def check_metadata(self, file_path: str) -> str:
+        """Check file metadata."""
+        return self._run_command(["exiftool", file_path])
+
+    async def binwalk_scan(self, file_path: str, extract: bool = False) -> str:
+        """Scan with binwalk."""
+        if extract:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                result = self._run_command(["binwalk", "-e", "-C", tmpdir, file_path])
+                # List extracted files
+                extracted = self._run_command(["find", tmpdir, "-type", "f"])
+                return f"{result}\n\nExtracted files:\n{extracted}"
+        return self._run_command(["binwalk", file_path])
+
+    async def list_tools(self) -> str:
+        """List available tools."""
+        tools = [
+            "=== Stego-Toolkit Available Tools ===\n",
+            "Image Analysis:",
+            "  - exiftool     : Metadata extraction",
+            "  - binwalk      : Embedded file detection",
+            "  - zsteg        : LSB steganography detection (PNG/BMP)",
+            "  - stegoveritas : Comprehensive image analysis",
+            "  - pngcheck     : PNG validation",
+            "  - identify     : ImageMagick file info",
+            "",
+            "Steganography Tools:",
+            "  - steghide     : Hide/extract data in JPG/BMP/WAV",
+            "  - stegseek     : Fast steghide password cracker",
+            "  - stegcracker  : Steghide brute-forcer",
+            "  - outguess     : JPG steganography",
+            "  - jsteg        : JPEG LSB steganography",
+            "  - openstego    : PNG steganography",
+            "  - stegano-lsb  : Python LSB stego",
+            "",
+            "Audio Tools:",
+            "  - ffmpeg       : Audio/video processing",
+            "  - sox          : Audio manipulation",
+            "  - sonic-visualiser : Spectrogram analysis (GUI)",
+            "",
+            "Password Tools:",
+            "  - john         : Password cracker",
+            "  - hashcat      : GPU password cracker (GPU image)",
+            "  - crunch       : Wordlist generator",
+            "  - cewl         : Website wordlist generator",
+        ]
+        return "\n".join(tools)
+
+    def _run_command(self, cmd: list, stderr: bool = False) -> str:
+        """Run a shell command and return output."""
+        try:
+            if stderr:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+                return result.stderr or result.stdout
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            return result.stdout or result.stderr
+        except subprocess.TimeoutExpired:
+            return f"Command timed out: {' '.join(cmd)}"
+        except FileNotFoundError:
+            return f"Command not found: {cmd[0]}"
+        except Exception as e:
+            return f"Error running {cmd[0]}: {str(e)}"
+
+
+async def main():
+    """Main entry point."""
+    server = MCPServer()
+
+    # Read from stdin, write to stdout (stdio transport)
+    while True:
+        try:
+            line = sys.stdin.readline()
+            if not line:
+                break
+
+            request = json.loads(line)
+            response = await server.handle_request(request)
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+        except json.JSONDecodeError:
+            continue
+        except KeyboardInterrupt:
+            break
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/brute_jpg.sh
+++ b/scripts/brute_jpg.sh
@@ -1,53 +1,239 @@
 #!/bin/bash
+# =============================================================================
+# brute_jpg.sh - JPG steganography brute-force password cracking
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
+set -euo pipefail
 
-FILE=$1
-WORDLIST=$2
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
 
-echo "Checking file $FILE with wordlist $WORDLIST"
+# =============================================================================
+# Helper Functions
+# =============================================================================
 
-echo
-echo "##############################"
-echo "########## steghide ##########"
-echo "##############################"
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] <image.jpg> <wordlist.txt>
 
-pybrute.py -f $FILE -w $WORDLIST steghide
+Brute-force password cracking for JPG steganography files.
 
-echo
-echo "##############################"
-echo "########## outguess ##########"
-echo "##############################"
+Uses multiple tools to try extracting hidden data:
+  - stegseek (fastest - recommended for steghide files)
+  - stegcracker (steghide brute-forcer)
+  - steghide
+  - outguess / outguess-0.13
+  - stegbreak
 
-pybrute.py -f $FILE -w $WORDLIST outguess
+Options:
+    -h, --help          Show this help message
+    -t, --threads NUM   Number of threads (default: 4)
+    -s, --stegseek-only Only use stegseek (fastest option)
+    -o, --output DIR    Output directory for extracted files
 
-echo
-echo "###################################"
-echo "########## outguess-0.13 ##########"
-echo "###################################"
+Examples:
+    $(basename "$0") suspicious.jpg rockyou.txt
+    $(basename "$0") -s suspicious.jpg wordlist.txt
+    $(basename "$0") -t 8 image.jpg passwords.txt
+EOF
+    exit 0
+}
 
-pybrute.py -f $FILE -w $WORDLIST outguess-0.13
+print_header() {
+    echo ""
+    echo -e "${BLUE}${BOLD}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}${BOLD}║${NC} ${CYAN}$1${NC}"
+    echo -e "${BLUE}${BOLD}╚════════════════════════════════════════════════════════════╝${NC}"
+}
 
-echo
-echo "###############################"
-echo "########## stegbreak ##########"
-echo "###############################"
+print_section() {
+    echo ""
+    echo -e "${YELLOW}━━━━━ $1 ━━━━━${NC}"
+}
 
-echo " -stegbreak (format=outguess)"
-stegbreak -t o -f $WORDLIST $FILE
+print_success() {
+    echo -e "${GREEN}[+]${NC} $1"
+}
 
-echo " -stegbreak (format=jphide)"
-stegbreak -t p -f $WORDLIST $FILE
+print_warning() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
 
-echo " -stegbreak (format=jsteg)"
-stegbreak -t j -f $WORDLIST $FILE
+print_error() {
+    echo -e "${RED}[-]${NC} $1"
+}
 
-echo
-echo "##################################"
-echo "########## stegoVeritas ##########"
-echo "##################################"
+print_info() {
+    echo -e "${CYAN}[*]${NC} $1"
+}
 
-# UUID=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
-# TMP_DIR=/data/stegoVeritas/$UUID
-# mkdir -p $TMP_DIR
-#
-# echo "Running stegoVerits takes time. Be patient and check out '$TMP_DIR' afterwards..."
-# stegoveritas.py $FILE -outDir $TMP_DIR -bruteLSB
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        print_warning "Tool '$1' not found - skipping"
+        return 1
+    fi
+    return 0
+}
+
+# =============================================================================
+# Parse Arguments
+# =============================================================================
+
+THREADS=4
+STEGSEEK_ONLY=0
+OUTPUT_DIR=""
+FILE=""
+WORDLIST=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        -t|--threads)
+            THREADS="$2"
+            shift 2
+            ;;
+        -s|--stegseek-only)
+            STEGSEEK_ONLY=1
+            shift
+            ;;
+        -o|--output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -*)
+            print_error "Unknown option: $1"
+            usage
+            ;;
+        *)
+            if [[ -z "$FILE" ]]; then
+                FILE="$1"
+            elif [[ -z "$WORDLIST" ]]; then
+                WORDLIST="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Validate input
+if [[ -z "$FILE" ]] || [[ -z "$WORDLIST" ]]; then
+    print_error "Missing required arguments"
+    usage
+fi
+
+if [[ ! -f "$FILE" ]]; then
+    print_error "Image file not found: $FILE"
+    exit 1
+fi
+
+if [[ ! -f "$WORDLIST" ]]; then
+    print_error "Wordlist not found: $WORDLIST"
+    exit 1
+fi
+
+# Create output directory if specified
+if [[ -n "$OUTPUT_DIR" ]]; then
+    mkdir -p "$OUTPUT_DIR"
+fi
+
+# =============================================================================
+# Main Brute Force
+# =============================================================================
+
+print_header "JPG STEGANOGRAPHY BRUTE-FORCER"
+print_info "Image: ${BOLD}$FILE${NC}"
+print_info "Wordlist: ${BOLD}$WORDLIST${NC}"
+WORDLIST_SIZE=$(wc -l < "$WORDLIST" 2>/dev/null || echo "unknown")
+print_info "Wordlist size: ${WORDLIST_SIZE} passwords"
+print_info "Threads: $THREADS"
+echo ""
+
+# =============================================================================
+# STEGSEEK - Lightning fast steghide cracker (RECOMMENDED)
+# =============================================================================
+print_section "STEGSEEK (Recommended - Fastest)"
+if check_command stegseek; then
+    print_info "Running stegseek - this is the fastest steghide cracker"
+    print_info "Can crack rockyou.txt in under 2 seconds!"
+    OUTPUT_FILE="${OUTPUT_DIR:-/tmp}/stegseek_output_$$.txt"
+
+    if stegseek "$FILE" "$WORDLIST" -xf "$OUTPUT_FILE" -t "$THREADS" 2>&1; then
+        if [[ -f "$OUTPUT_FILE" ]]; then
+            print_success "Password found! Extracted data saved to: $OUTPUT_FILE"
+        fi
+    else
+        print_info "No password found with stegseek"
+    fi
+fi
+
+# If stegseek-only mode, stop here
+if [[ "$STEGSEEK_ONLY" -eq 1 ]]; then
+    print_info "Stegseek-only mode - stopping here"
+    exit 0
+fi
+
+# =============================================================================
+# STEGCRACKER - Python steghide brute-forcer
+# =============================================================================
+print_section "STEGCRACKER"
+if check_command stegcracker; then
+    print_info "Running stegcracker..."
+    stegcracker "$FILE" "$WORDLIST" -t "$THREADS" 2>&1 || true
+fi
+
+# =============================================================================
+# PYBRUTE - Legacy brute-forcer (multiple tools)
+# =============================================================================
+print_section "STEGHIDE (via pybrute)"
+if check_command pybrute.py; then
+    print_info "Running pybrute with steghide..."
+    pybrute.py -f "$FILE" -w "$WORDLIST" -t "$THREADS" steghide 2>&1 || true
+fi
+
+print_section "OUTGUESS (via pybrute)"
+if check_command pybrute.py; then
+    print_info "Running pybrute with outguess..."
+    pybrute.py -f "$FILE" -w "$WORDLIST" -t "$THREADS" outguess 2>&1 || true
+fi
+
+print_section "OUTGUESS-0.13 (via pybrute)"
+if check_command pybrute.py; then
+    print_info "Running pybrute with outguess-0.13..."
+    pybrute.py -f "$FILE" -w "$WORDLIST" -t "$THREADS" outguess-0.13 2>&1 || true
+fi
+
+# =============================================================================
+# STEGBREAK - Native JPG cracker
+# =============================================================================
+print_section "STEGBREAK"
+if check_command stegbreak; then
+    print_info "Running stegbreak (outguess format)..."
+    stegbreak -t o -f "$WORDLIST" "$FILE" 2>&1 || true
+
+    print_info "Running stegbreak (jphide format)..."
+    stegbreak -t p -f "$WORDLIST" "$FILE" 2>&1 || true
+
+    print_info "Running stegbreak (jsteg format)..."
+    stegbreak -t j -f "$WORDLIST" "$FILE" 2>&1 || true
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+print_header "BRUTE-FORCE COMPLETE"
+print_info "Checked file: $FILE"
+print_info "Wordlist used: $WORDLIST"
+echo ""
+print_info "Tips:"
+print_info "  - For fastest results, use stegseek with rockyou.txt"
+print_info "  - Generate custom wordlists with: john, crunch, or cewl"
+print_info "  - Example: cewl -d 2 -m 6 https://target.com > custom.txt"
+echo ""

--- a/scripts/brute_png.sh
+++ b/scripts/brute_png.sh
@@ -1,25 +1,187 @@
 #!/bin/bash
+# =============================================================================
+# brute_png.sh - PNG steganography brute-force password cracking
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
+set -euo pipefail
 
-FILE=$1
-WORDLIST=$2
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
 
-echo "Checking file $FILE with wordlist $WORDLIST"
+# =============================================================================
+# Helper Functions
+# =============================================================================
 
-echo
-echo "###############################"
-echo "########## openstego ##########"
-echo "###############################"
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] <image.png> <wordlist.txt>
 
-pybrute.py -f $FILE -w $WORDLIST openstego
+Brute-force password cracking for PNG steganography files.
 
-echo
-echo "##################################"
-echo "########## stegoVeritas ##########"
-echo "##################################"
+Uses multiple tools to try extracting hidden data:
+  - openstego
+  - stegoveritas (LSB brute-force)
 
-UUID=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
-TMP_DIR=/data/stegoVeritas/$UUID
-mkdir -p $TMP_DIR
+Options:
+    -h, --help          Show this help message
+    -t, --threads NUM   Number of threads (default: 4)
+    -o, --output DIR    Output directory for extracted files
 
-echo "Running stegoVerits takes time. Be patient and check out '$TMP_DIR' afterwards..."
-stegoveritas.py $FILE -outDir $TMP_DIR -meta -bruteLSB -imageTransform -colorMap -trailing
+Examples:
+    $(basename "$0") suspicious.png rockyou.txt
+    $(basename "$0") -t 8 image.png passwords.txt
+    $(basename "$0") -o ./output image.png wordlist.txt
+EOF
+    exit 0
+}
+
+print_header() {
+    echo ""
+    echo -e "${BLUE}${BOLD}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}${BOLD}║${NC} ${CYAN}$1${NC}"
+    echo -e "${BLUE}${BOLD}╚════════════════════════════════════════════════════════════╝${NC}"
+}
+
+print_section() {
+    echo ""
+    echo -e "${YELLOW}━━━━━ $1 ━━━━━${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}[+]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[-]${NC} $1"
+}
+
+print_info() {
+    echo -e "${CYAN}[*]${NC} $1"
+}
+
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        print_warning "Tool '$1' not found - skipping"
+        return 1
+    fi
+    return 0
+}
+
+# =============================================================================
+# Parse Arguments
+# =============================================================================
+
+THREADS=4
+OUTPUT_DIR=""
+FILE=""
+WORDLIST=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        -t|--threads)
+            THREADS="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -*)
+            print_error "Unknown option: $1"
+            usage
+            ;;
+        *)
+            if [[ -z "$FILE" ]]; then
+                FILE="$1"
+            elif [[ -z "$WORDLIST" ]]; then
+                WORDLIST="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Validate input
+if [[ -z "$FILE" ]] || [[ -z "$WORDLIST" ]]; then
+    print_error "Missing required arguments"
+    usage
+fi
+
+if [[ ! -f "$FILE" ]]; then
+    print_error "Image file not found: $FILE"
+    exit 1
+fi
+
+if [[ ! -f "$WORDLIST" ]]; then
+    print_error "Wordlist not found: $WORDLIST"
+    exit 1
+fi
+
+# Create output directory if specified
+if [[ -n "$OUTPUT_DIR" ]]; then
+    mkdir -p "$OUTPUT_DIR"
+fi
+
+# =============================================================================
+# Main Brute Force
+# =============================================================================
+
+print_header "PNG STEGANOGRAPHY BRUTE-FORCER"
+print_info "Image: ${BOLD}$FILE${NC}"
+print_info "Wordlist: ${BOLD}$WORDLIST${NC}"
+WORDLIST_SIZE=$(wc -l < "$WORDLIST" 2>/dev/null || echo "unknown")
+print_info "Wordlist size: ${WORDLIST_SIZE} passwords"
+print_info "Threads: $THREADS"
+echo ""
+
+# =============================================================================
+# OPENSTEGO - via pybrute
+# =============================================================================
+print_section "OPENSTEGO"
+if check_command pybrute.py && check_command openstego; then
+    print_info "Running pybrute with openstego..."
+    pybrute.py -f "$FILE" -w "$WORDLIST" -t "$THREADS" openstego 2>&1 || true
+fi
+
+# =============================================================================
+# STEGOVERITAS - LSB Brute Force
+# =============================================================================
+print_section "STEGOVERITAS (LSB Brute-Force)"
+if check_command stegoveritas; then
+    UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+    TMP_DIR="${OUTPUT_DIR:-/tmp}/stegoveritas_${UUID}"
+    mkdir -p "$TMP_DIR"
+
+    print_info "Running stegoveritas with LSB brute-force..."
+    print_warning "This may take a while. Results will be saved to: $TMP_DIR"
+
+    stegoveritas "$FILE" -out "$TMP_DIR" -meta -bruteLSB -imageTransform -colorMap -trailing 2>&1 || true
+
+    print_info "Check $TMP_DIR for results"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+print_header "BRUTE-FORCE COMPLETE"
+print_info "Checked file: $FILE"
+print_info "Wordlist used: $WORDLIST"
+echo ""
+print_info "Tips:"
+print_info "  - PNG files often use LSB steganography (check zsteg output)"
+print_info "  - Try check_png.sh first to identify the encoding method"
+print_info "  - Generate custom wordlists with: john, crunch, or cewl"
+echo ""

--- a/scripts/check_jpg.sh
+++ b/scripts/check_jpg.sh
@@ -1,113 +1,276 @@
 #!/bin/bash
+# =============================================================================
+# check_jpg.sh - Automated JPG steganography screening
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
+set -euo pipefail
 
-FILE=$1
-TMP_FILE=/tmp/out
-
+# Colors for output
 RED='\033[0;31m'
-NO_COLOR='\033[0m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
 
-check_result_file() {
-  RESULT_FILE=$1
-  HINT=${2:""}
-  if [ ! -f "$RESULT_FILE" ]; then
-    echo "Nothing found..."
-    return
-  fi
+# Configuration
+TMP_FILE="/tmp/stego_out_$$"
+REPORT_DIR=""
+VERBOSE=0
 
-  SIZE=`stat -c %s "$RESULT_FILE"`
-  if [ ! "`file $RESULT_FILE`" = "$RESULT_FILE: data" ] && [ $SIZE -ge 1 ]; then
-    echo ""
-    echo -e "${RED}Found something!!!${NO_COLOR}"
-    echo "Result size: $SIZE (type: '`file $RESULT_FILE`')"
-    echo "--------------"
-    head -n 20 $RESULT_FILE
-    echo "--------------"
-  else
-    echo "Probably no result..."
-    echo "Result size: $SIZE (type: '`file $RESULT_FILE`')"
-  fi
-  rm $RESULT_FILE
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] <image.jpg>
+
+Automated screening script for JPG files to detect steganography.
+
+Options:
+    -h, --help      Show this help message
+    -v, --verbose   Enable verbose output
+    -o, --output    Output directory for detailed reports
+    -q, --quiet     Suppress non-essential output
+
+Examples:
+    $(basename "$0") suspicious.jpg
+    $(basename "$0") -v -o ./reports suspicious.jpg
+    $(basename "$0") --help
+EOF
+    exit 0
 }
 
-echo
-echo "#################################"
-echo "########## JPG CHECKER ##########"
-echo "#################################"
-echo "Checking file $FILE"
-echo
-echo "file $FILE:"
-file $FILE
+print_header() {
+    echo ""
+    echo -e "${BLUE}${BOLD}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}${BOLD}║${NC} ${CYAN}$1${NC}"
+    echo -e "${BLUE}${BOLD}╚════════════════════════════════════════════════════════════╝${NC}"
+}
 
-echo "identify $FILE:"
-identify -verbose $FILE
+print_section() {
+    echo ""
+    echo -e "${YELLOW}━━━━━ $1 ━━━━━${NC}"
+}
 
-echo
-echo "##############################"
-echo "########## exiftool ##########"
-echo "##############################"
+print_success() {
+    echo -e "${GREEN}[+]${NC} $1"
+}
 
-exiftool $FILE
+print_warning() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
 
-echo
-echo "#############################"
-echo "########## binwalk ##########"
-echo "#############################"
+print_error() {
+    echo -e "${RED}[-]${NC} $1"
+}
 
-binwalk $FILE
+print_info() {
+    echo -e "${CYAN}[*]${NC} $1"
+}
 
-echo
-echo "################################"
-echo "########## stegdetect ##########"
-echo "################################"
+check_result_file() {
+    local RESULT_FILE="$1"
+    local TOOL_NAME="${2:-Unknown}"
 
-stegdetect $FILE
+    if [[ ! -f "$RESULT_FILE" ]]; then
+        print_info "No output file generated"
+        return 1
+    fi
 
-echo
-echo "#############################"
-echo "########## strings ##########"
-echo "#############################"
+    local SIZE
+    SIZE=$(stat -c %s "$RESULT_FILE" 2>/dev/null || echo "0")
+    local FILE_TYPE
+    FILE_TYPE=$(file -b "$RESULT_FILE" 2>/dev/null || echo "unknown")
 
-strings $FILE | head -n 20
-echo "..."
-strings $FILE | tail -n 20
+    if [[ "$FILE_TYPE" != "data" ]] && [[ "$SIZE" -ge 1 ]]; then
+        echo ""
+        print_success "${BOLD}POTENTIAL DATA FOUND!${NC}"
+        echo -e "  Size: ${SIZE} bytes"
+        echo -e "  Type: ${FILE_TYPE}"
+        echo -e "  ${CYAN}Preview:${NC}"
+        echo "  ─────────────────────────────"
+        head -n 20 "$RESULT_FILE" | sed 's/^/  /'
+        echo "  ─────────────────────────────"
 
-echo
-echo "##############################"
-echo "########## steghide ##########"
-echo "##############################"
+        if [[ -n "$REPORT_DIR" ]]; then
+            local REPORT_FILE="${REPORT_DIR}/${TOOL_NAME}_output.txt"
+            cp "$RESULT_FILE" "$REPORT_FILE"
+            print_info "Full output saved to: $REPORT_FILE"
+        fi
+        rm -f "$RESULT_FILE"
+        return 0
+    else
+        print_info "No meaningful data extracted (${SIZE} bytes, type: ${FILE_TYPE})"
+        rm -f "$RESULT_FILE"
+        return 1
+    fi
+}
 
-steghide extract -sf $FILE -p ""
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        print_warning "Tool '$1' not found - skipping"
+        return 1
+    fi
+    return 0
+}
 
-echo
-echo "##############################"
-echo "########## outguess ##########"
-echo "##############################"
+# =============================================================================
+# Parse Arguments
+# =============================================================================
 
-outguess -r $FILE $TMP_FILE
-check_result_file $TMP_FILE
+QUIET=0
+FILE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        -v|--verbose)
+            VERBOSE=1
+            shift
+            ;;
+        -q|--quiet)
+            QUIET=1
+            shift
+            ;;
+        -o|--output)
+            REPORT_DIR="$2"
+            shift 2
+            ;;
+        -*)
+            print_error "Unknown option: $1"
+            usage
+            ;;
+        *)
+            FILE="$1"
+            shift
+            ;;
+    esac
+done
 
-echo
-echo "###################################"
-echo "########## outguess-0.13 ##########"
-echo "###################################"
+# Validate input
+if [[ -z "${FILE:-}" ]]; then
+    print_error "No input file specified"
+    usage
+fi
 
-outguess-0.13 -r $FILE $TMP_FILE
-check_result_file $TMP_FILE
+if [[ ! -f "$FILE" ]]; then
+    print_error "File not found: $FILE"
+    exit 1
+fi
 
-echo
-echo "###########################"
-echo "########## jsteg ##########"
-echo "###########################"
+# Create report directory if specified
+if [[ -n "$REPORT_DIR" ]]; then
+    mkdir -p "$REPORT_DIR"
+fi
 
-jsteg reveal $FILE $TMP_FILE
-check_result_file $TMP_FILE
+# =============================================================================
+# Main Analysis
+# =============================================================================
 
-echo
-echo "##################################"
-echo "########## stegoVeritas ##########"
-echo "##################################"
+print_header "JPG STEGANOGRAPHY CHECKER"
+print_info "Analyzing: ${BOLD}$FILE${NC}"
+print_info "Date: $(date)"
+echo ""
 
-UUID=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
-TMP_DIR=/data/stegoVeritas/$UUID
-mkdir -p $TMP_DIR
-stegoveritas $FILE -out $TMP_DIR -meta -imageTransform -colorMap -trailing
+# Basic file information
+print_section "FILE INFORMATION"
+if check_command file; then
+    file "$FILE"
+fi
+
+if check_command identify; then
+    print_info "ImageMagick identify:"
+    identify -verbose "$FILE" 2>/dev/null | head -30 || true
+fi
+
+# Metadata analysis
+print_section "METADATA (exiftool)"
+if check_command exiftool; then
+    exiftool "$FILE" || true
+fi
+
+# Embedded file detection
+print_section "EMBEDDED FILES (binwalk)"
+if check_command binwalk; then
+    binwalk "$FILE" || true
+fi
+
+# Stegdetect analysis
+print_section "STEGDETECT ANALYSIS"
+if check_command stegdetect; then
+    stegdetect "$FILE" || true
+fi
+
+# Strings analysis
+print_section "STRINGS ANALYSIS"
+if check_command strings; then
+    print_info "First 20 strings:"
+    strings "$FILE" | head -n 20
+    echo "..."
+    print_info "Last 20 strings:"
+    strings "$FILE" | tail -n 20
+fi
+
+# Steghide (empty password)
+print_section "STEGHIDE (empty password)"
+if check_command steghide; then
+    steghide extract -sf "$FILE" -p "" -xf "$TMP_FILE" 2>&1 || true
+    check_result_file "$TMP_FILE" "steghide_empty" || true
+fi
+
+# Stegseek (seed detection - no password needed)
+print_section "STEGSEEK SEED DETECTION"
+if check_command stegseek; then
+    print_info "Checking for steghide content without password..."
+    stegseek --seed "$FILE" 2>&1 || true
+fi
+
+# Outguess
+print_section "OUTGUESS"
+if check_command outguess; then
+    outguess -r "$FILE" "$TMP_FILE" 2>&1 || true
+    check_result_file "$TMP_FILE" "outguess" || true
+fi
+
+# Outguess 0.13
+print_section "OUTGUESS-0.13"
+if check_command outguess-0.13; then
+    outguess-0.13 -r "$FILE" "$TMP_FILE" 2>&1 || true
+    check_result_file "$TMP_FILE" "outguess-0.13" || true
+fi
+
+# jsteg
+print_section "JSTEG"
+if check_command jsteg; then
+    jsteg reveal "$FILE" "$TMP_FILE" 2>&1 || true
+    check_result_file "$TMP_FILE" "jsteg" || true
+fi
+
+# stegoveritas
+print_section "STEGOVERITAS"
+if check_command stegoveritas; then
+    UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+    TMP_DIR="${REPORT_DIR:-/tmp}/stegoveritas_${UUID}"
+    mkdir -p "$TMP_DIR"
+    print_info "Running stegoveritas (output: $TMP_DIR)..."
+    stegoveritas "$FILE" -out "$TMP_DIR" -meta -imageTransform -colorMap -trailing 2>&1 || true
+    print_info "Check $TMP_DIR for detailed analysis results"
+fi
+
+# Cleanup
+rm -f "$TMP_FILE" 2>/dev/null || true
+
+# Summary
+print_header "ANALYSIS COMPLETE"
+print_info "File: $FILE"
+print_info "Completed: $(date)"
+if [[ -n "$REPORT_DIR" ]]; then
+    print_info "Reports saved to: $REPORT_DIR"
+fi
+echo ""
+print_info "Tip: Use 'brute_jpg.sh' with a wordlist to attempt password cracking"
+echo ""

--- a/scripts/check_png.sh
+++ b/scripts/check_png.sh
@@ -1,143 +1,289 @@
 #!/bin/bash
+# =============================================================================
+# check_png.sh - Automated PNG steganography screening
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
+set -euo pipefail
 
-FILE=$1
-TMP_FILE=/tmp/out
-
+# Colors for output
 RED='\033[0;31m'
-NO_COLOR='\033[0m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
 
-check_result_file() {
-  RESULT_FILE=$1
-  if [ ! -f "$RESULT_FILE" ]; then
-    echo "Nothing found..."
-    return
-  fi
+# Configuration
+TMP_FILE="/tmp/stego_out_$$"
+REPORT_DIR=""
+VERBOSE=0
 
-  SIZE=`stat -c %s "$RESULT_FILE"`
-  if [ ! "`file $RESULT_FILE`" = "$RESULT_FILE: data" ] && [ $SIZE -ge 1 ]; then
-    echo ""
-    echo -e "${RED}Found something!!!${NO_COLOR}"
-    echo "Result size: $SIZE (type: '`file $RESULT_FILE`')"
-    echo "--------------"
-    head -n 20 $RESULT_FILE
-    echo "--------------"
-  else
-    echo ""
-    echo "Probably no result..."
-    echo "Result size: $SIZE (type: '`file $RESULT_FILE`')"
-  fi
-  rm $RESULT_FILE
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] <image.png>
+
+Automated screening script for PNG files to detect steganography.
+
+Options:
+    -h, --help      Show this help message
+    -v, --verbose   Enable verbose output
+    -o, --output    Output directory for detailed reports
+    -q, --quiet     Suppress non-essential output
+
+Examples:
+    $(basename "$0") suspicious.png
+    $(basename "$0") -v -o ./reports suspicious.png
+    $(basename "$0") --help
+EOF
+    exit 0
 }
 
-echo
-echo "#################################"
-echo "########## PNG CHECKER ##########"
-echo "#################################"
-echo "Checking file $FILE"
-echo
-file $FILE
+print_header() {
+    echo ""
+    echo -e "${BLUE}${BOLD}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}${BOLD}║${NC} ${CYAN}$1${NC}"
+    echo -e "${BLUE}${BOLD}╚════════════════════════════════════════════════════════════╝${NC}"
+}
 
-echo "identify $FILE:"
-identify  -verbose $FILE
+print_section() {
+    echo ""
+    echo -e "${YELLOW}━━━━━ $1 ━━━━━${NC}"
+}
 
-echo
-echo "##############################"
-echo "########## exiftool ##########"
-echo "##############################"
+print_success() {
+    echo -e "${GREEN}[+]${NC} $1"
+}
 
-exiftool $FILE
+print_warning() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
 
-echo
-echo "#############################"
-echo "########## binwalk ##########"
-echo "#############################"
+print_error() {
+    echo -e "${RED}[-]${NC} $1"
+}
 
-binwalk $FILE
+print_info() {
+    echo -e "${CYAN}[*]${NC} $1"
+}
 
-echo
-echo "################################"
-echo "########## stegdetect ##########"
-echo "################################"
+check_result_file() {
+    local RESULT_FILE="$1"
+    local TOOL_NAME="${2:-Unknown}"
 
-stegdetect $FILE
+    if [[ ! -f "$RESULT_FILE" ]]; then
+        print_info "No output file generated"
+        return 1
+    fi
 
-echo
-echo "#############################"
-echo "########## strings ##########"
-echo "#############################"
+    local SIZE
+    SIZE=$(stat -c %s "$RESULT_FILE" 2>/dev/null || echo "0")
+    local FILE_TYPE
+    FILE_TYPE=$(file -b "$RESULT_FILE" 2>/dev/null || echo "unknown")
 
-strings $FILE | head -n 20
-echo "..."
-strings $FILE | tail -n 20
+    if [[ "$FILE_TYPE" != "data" ]] && [[ "$SIZE" -ge 1 ]]; then
+        echo ""
+        print_success "${BOLD}POTENTIAL DATA FOUND!${NC}"
+        echo -e "  Size: ${SIZE} bytes"
+        echo -e "  Type: ${FILE_TYPE}"
+        echo -e "  ${CYAN}Preview:${NC}"
+        echo "  ─────────────────────────────"
+        head -n 20 "$RESULT_FILE" | sed 's/^/  /'
+        echo "  ─────────────────────────────"
 
-echo
-echo "###########################"
-echo "########## zsteg ##########"
-echo "###########################"
-echo
-echo "Watch out for red output. This tool shows lots of false positives..."
+        if [[ -n "$REPORT_DIR" ]]; then
+            local REPORT_FILE="${REPORT_DIR}/${TOOL_NAME}_output.txt"
+            cp "$RESULT_FILE" "$REPORT_FILE"
+            print_info "Full output saved to: $REPORT_FILE"
+        fi
+        rm -f "$RESULT_FILE"
+        return 0
+    else
+        print_info "No meaningful data extracted (${SIZE} bytes, type: ${FILE_TYPE})"
+        rm -f "$RESULT_FILE"
+        return 1
+    fi
+}
 
-zsteg $FILE -a
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        print_warning "Tool '$1' not found - skipping"
+        return 1
+    fi
+    return 0
+}
 
-echo
-echo "###############################"
-echo "########## openstego ##########"
-echo "###############################"
+# =============================================================================
+# Parse Arguments
+# =============================================================================
 
-openstego extract -sf $FILE -p "''" -xf $TMP_FILE
-check_result_file $TMP_FILE
-
-echo
-echo "#################################"
-echo "########## stegano-lsb ##########"
-echo "#################################"
-
-for ENCODING in UTF-8 UTF-32LE; do
-  echo "- stegano-lsb (encoding $ENCODING)"
-  stegano-lsb reveal --input $FILE -e $ENCODING -o $TMP_FILE
-  check_result_file $TMP_FILE
+QUIET=0
+FILE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        -v|--verbose)
+            VERBOSE=1
+            shift
+            ;;
+        -q|--quiet)
+            QUIET=1
+            shift
+            ;;
+        -o|--output)
+            REPORT_DIR="$2"
+            shift 2
+            ;;
+        -*)
+            print_error "Unknown option: $1"
+            usage
+            ;;
+        *)
+            FILE="$1"
+            shift
+            ;;
+    esac
 done
 
-echo
-echo "#####################################"
-echo "########## stegano-lsb-set ##########"
-echo "#####################################"
+# Validate input
+if [[ -z "${FILE:-}" ]]; then
+    print_error "No input file specified"
+    usage
+fi
 
-# TODO: check why stegano is so buggy...
-# - geneators not working: ackermann ackermann_naive (require arguments - how to parse?)
+if [[ ! -f "$FILE" ]]; then
+    print_error "File not found: $FILE"
+    exit 1
+fi
 
-for GENERATOR in composite eratosthenes fermat fibonacci identity log_gen mersenne triangular_numbers; do
-  # generator 'carmichael' left out since it is slow
-  for ENCODING in UTF-8 UTF-32LE; do
-    echo "- stegano-lsb-set (generator $GENERATOR | encoding $ENCODING)"
-    stegano-lsb-set reveal --input $FILE -e $ENCODING -g $GENERATOR -o $TMP_FILE
-    check_result_file $TMP_FILE
-  done
-done
+# Create report directory if specified
+if [[ -n "$REPORT_DIR" ]]; then
+    mkdir -p "$REPORT_DIR"
+fi
 
-echo
-echo "#################################"
-echo "########## stegano-red ##########"
-echo "#################################"
+# =============================================================================
+# Main Analysis
+# =============================================================================
 
-stegano-red reveal --input $FILE
+print_header "PNG STEGANOGRAPHY CHECKER"
+print_info "Analyzing: ${BOLD}$FILE${NC}"
+print_info "Date: $(date)"
+echo ""
 
-echo
-echo "##############################"
-echo "########## LSBSteg  ##########"
-echo "##############################"
+# Basic file information
+print_section "FILE INFORMATION"
+if check_command file; then
+    file "$FILE"
+fi
 
-# seems to fail most of the time we did not encode something with it
-# no file will be created in these cases
-LSBSteg decode -i $FILE -o $TMP_FILE 2>/dev/null
-check_result_file $TMP_FILE
+if check_command pngcheck; then
+    print_info "PNG validation:"
+    pngcheck -v "$FILE" 2>&1 || true
+fi
 
-echo
-echo "##################################"
-echo "########## stegoVeritas ##########"
-echo "##################################"
+if check_command identify; then
+    print_info "ImageMagick identify:"
+    identify -verbose "$FILE" 2>/dev/null | head -30 || true
+fi
 
-UUID=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
-TMP_DIR=/data/stegoVeritas/$UUID
-mkdir -p $TMP_DIR
-stegoveritas $FILE -out $TMP_DIR -meta -imageTransform -colorMap -trailing
+# Metadata analysis
+print_section "METADATA (exiftool)"
+if check_command exiftool; then
+    exiftool "$FILE" || true
+fi
+
+# Embedded file detection
+print_section "EMBEDDED FILES (binwalk)"
+if check_command binwalk; then
+    binwalk "$FILE" || true
+fi
+
+# Strings analysis
+print_section "STRINGS ANALYSIS"
+if check_command strings; then
+    print_info "First 20 strings:"
+    strings "$FILE" | head -n 20
+    echo "..."
+    print_info "Last 20 strings:"
+    strings "$FILE" | tail -n 20
+fi
+
+# zsteg - PNG/BMP LSB detection
+print_section "ZSTEG (LSB ANALYSIS)"
+if check_command zsteg; then
+    print_warning "Watch out for red output - zsteg shows lots of false positives..."
+    zsteg "$FILE" -a 2>&1 || true
+fi
+
+# OpenStego (empty password)
+print_section "OPENSTEGO (empty password)"
+if check_command openstego; then
+    openstego extract -sf "$FILE" -p "" -xf "$TMP_FILE" 2>&1 || true
+    check_result_file "$TMP_FILE" "openstego_empty" || true
+fi
+
+# Stegano LSB
+print_section "STEGANO-LSB"
+if check_command stegano-lsb; then
+    for ENCODING in UTF-8 UTF-32LE; do
+        print_info "stegano-lsb (encoding: $ENCODING)"
+        stegano-lsb reveal --input "$FILE" -e "$ENCODING" -o "$TMP_FILE" 2>&1 || true
+        check_result_file "$TMP_FILE" "stegano_lsb_${ENCODING}" || true
+    done
+fi
+
+# Stegano LSB-set with various generators
+print_section "STEGANO-LSB-SET"
+if check_command stegano-lsb-set; then
+    for GENERATOR in composite eratosthenes fermat fibonacci identity log_gen mersenne triangular_numbers; do
+        for ENCODING in UTF-8 UTF-32LE; do
+            print_info "stegano-lsb-set (generator: $GENERATOR, encoding: $ENCODING)"
+            stegano-lsb-set reveal --input "$FILE" -e "$ENCODING" -g "$GENERATOR" -o "$TMP_FILE" 2>&1 || true
+            check_result_file "$TMP_FILE" "stegano_lsb_set_${GENERATOR}_${ENCODING}" || true
+        done
+    done
+fi
+
+# Stegano Red
+print_section "STEGANO-RED"
+if check_command stegano-red; then
+    stegano-red reveal --input "$FILE" 2>&1 || true
+fi
+
+# LSBSteg
+print_section "LSBSTEG"
+if check_command LSBSteg; then
+    LSBSteg decode -i "$FILE" -o "$TMP_FILE" 2>/dev/null || true
+    check_result_file "$TMP_FILE" "LSBSteg" || true
+fi
+
+# stegoveritas
+print_section "STEGOVERITAS"
+if check_command stegoveritas; then
+    UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+    TMP_DIR="${REPORT_DIR:-/tmp}/stegoveritas_${UUID}"
+    mkdir -p "$TMP_DIR"
+    print_info "Running stegoveritas (output: $TMP_DIR)..."
+    stegoveritas "$FILE" -out "$TMP_DIR" -meta -imageTransform -colorMap -trailing 2>&1 || true
+    print_info "Check $TMP_DIR for detailed analysis results"
+fi
+
+# Cleanup
+rm -f "$TMP_FILE" 2>/dev/null || true
+
+# Summary
+print_header "ANALYSIS COMPLETE"
+print_info "File: $FILE"
+print_info "Completed: $(date)"
+if [[ -n "$REPORT_DIR" ]]; then
+    print_info "Reports saved to: $REPORT_DIR"
+fi
+echo ""
+print_info "Tip: Use 'brute_png.sh' with a wordlist to attempt password cracking"
+echo ""

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+# =============================================================================
+# smoke_test.sh - Smoke tests for stego-toolkit Docker image
+# Part of stego-toolkit (2025 refresh)
+# =============================================================================
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Configuration
+IMAGE_NAME="${1:-stego-toolkit:test}"
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+print_header() {
+    echo ""
+    echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  $1${NC}"
+    echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+}
+
+print_test() {
+    echo -e "${YELLOW}[TEST]${NC} $1"
+}
+
+print_pass() {
+    echo -e "${GREEN}[PASS]${NC} $1"
+    ((PASSED++))
+}
+
+print_fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    ((FAILED++))
+}
+
+print_skip() {
+    echo -e "${YELLOW}[SKIP]${NC} $1"
+    ((SKIPPED++))
+}
+
+run_in_container() {
+    docker run --rm "$IMAGE_NAME" "$@"
+}
+
+test_command_exists() {
+    local cmd="$1"
+    local description="${2:-$cmd}"
+
+    print_test "Checking if '$cmd' exists..."
+    if run_in_container which "$cmd" > /dev/null 2>&1; then
+        print_pass "$description is available"
+        return 0
+    else
+        print_fail "$description is NOT available"
+        return 1
+    fi
+}
+
+test_command_runs() {
+    local cmd="$1"
+    local args="${2:---help}"
+    local description="${3:-$cmd}"
+
+    print_test "Testing '$cmd $args'..."
+    if run_in_container bash -c "$cmd $args" > /dev/null 2>&1; then
+        print_pass "$description runs successfully"
+        return 0
+    else
+        print_fail "$description failed to run"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+print_header "STEGO-TOOLKIT SMOKE TESTS"
+echo "Image: $IMAGE_NAME"
+echo "Date: $(date)"
+echo ""
+
+# Check if image exists
+print_test "Checking if Docker image exists..."
+if docker image inspect "$IMAGE_NAME" > /dev/null 2>&1; then
+    print_pass "Docker image '$IMAGE_NAME' found"
+else
+    print_fail "Docker image '$IMAGE_NAME' not found"
+    echo "Please build the image first: docker build -t $IMAGE_NAME ."
+    exit 1
+fi
+
+# =============================================================================
+# Core System Tools
+# =============================================================================
+print_header "CORE SYSTEM TOOLS"
+
+test_command_exists "file" "file (magic number detection)"
+test_command_exists "strings" "strings"
+test_command_exists "hexdump" "hexdump"
+test_command_exists "xxd" "xxd"
+
+# =============================================================================
+# Forensics Tools
+# =============================================================================
+print_header "FORENSICS TOOLS"
+
+test_command_exists "binwalk" "binwalk (firmware analysis)"
+test_command_exists "foremost" "foremost (file carving)"
+test_command_exists "exiftool" "exiftool (metadata)"
+
+# =============================================================================
+# Image Steganography Tools
+# =============================================================================
+print_header "IMAGE STEGANOGRAPHY TOOLS"
+
+test_command_exists "steghide" "steghide"
+test_command_exists "outguess" "outguess"
+test_command_exists "zsteg" "zsteg (Ruby)"
+test_command_exists "stegoveritas" "stegoveritas (Python)"
+test_command_exists "jsteg" "jsteg"
+test_command_exists "openstego" "OpenStego"
+
+# Check stegseek (new addition)
+test_command_exists "stegseek" "stegseek (fast steghide cracker)"
+
+# Check stegcracker (new addition)
+test_command_exists "stegcracker" "stegcracker"
+
+# =============================================================================
+# Stegano Python Library
+# =============================================================================
+print_header "STEGANO LIBRARY"
+
+test_command_exists "stegano-lsb" "stegano-lsb"
+test_command_exists "stegano-lsb-set" "stegano-lsb-set"
+
+# =============================================================================
+# Audio Tools
+# =============================================================================
+print_header "AUDIO TOOLS"
+
+test_command_exists "ffmpeg" "ffmpeg"
+test_command_exists "sox" "sox"
+test_command_exists "sonic-visualiser" "Sonic Visualiser"
+
+# =============================================================================
+# Password/Wordlist Tools
+# =============================================================================
+print_header "PASSWORD TOOLS"
+
+test_command_exists "john" "John the Ripper"
+test_command_exists "crunch" "crunch (wordlist generator)"
+test_command_exists "cewl" "CeWL (website wordlist generator)"
+
+# =============================================================================
+# Utility Tools
+# =============================================================================
+print_header "UTILITY TOOLS"
+
+test_command_exists "identify" "ImageMagick identify"
+test_command_exists "pngcheck" "pngcheck"
+test_command_exists "hexyl" "hexyl (hex viewer)"
+
+# =============================================================================
+# Custom Scripts
+# =============================================================================
+print_header "CUSTOM SCRIPTS"
+
+test_command_exists "check_jpg.sh" "check_jpg.sh"
+test_command_exists "check_png.sh" "check_png.sh"
+test_command_exists "brute_jpg.sh" "brute_jpg.sh"
+test_command_exists "brute_png.sh" "brute_png.sh"
+test_command_exists "pybrute.py" "pybrute.py"
+
+# Test script help messages
+print_test "Testing check_jpg.sh --help..."
+if run_in_container check_jpg.sh --help 2>&1 | grep -q "Usage:"; then
+    print_pass "check_jpg.sh shows help"
+else
+    print_fail "check_jpg.sh help not working"
+fi
+
+print_test "Testing brute_jpg.sh --help..."
+if run_in_container brute_jpg.sh --help 2>&1 | grep -q "Usage:"; then
+    print_pass "brute_jpg.sh shows help"
+else
+    print_fail "brute_jpg.sh help not working"
+fi
+
+# =============================================================================
+# Functional Tests with Sample Files
+# =============================================================================
+print_header "FUNCTIONAL TESTS"
+
+# Test with example files if they exist
+print_test "Testing exiftool on example JPG..."
+if run_in_container exiftool /examples/ORIGINAL.jpg 2>&1 | grep -q "File Type"; then
+    print_pass "exiftool can read example JPG"
+else
+    print_fail "exiftool failed on example JPG"
+fi
+
+print_test "Testing binwalk on example PNG..."
+if run_in_container binwalk /examples/ORIGINAL.png > /dev/null 2>&1; then
+    print_pass "binwalk can analyze example PNG"
+else
+    print_fail "binwalk failed on example PNG"
+fi
+
+print_test "Testing zsteg on example PNG..."
+if run_in_container zsteg /examples/ORIGINAL.png > /dev/null 2>&1; then
+    print_pass "zsteg can analyze example PNG"
+else
+    print_fail "zsteg failed on example PNG"
+fi
+
+# =============================================================================
+# Python Environment
+# =============================================================================
+print_header "PYTHON ENVIRONMENT"
+
+print_test "Testing Python 3..."
+if run_in_container python3 --version 2>&1 | grep -q "Python 3"; then
+    print_pass "Python 3 is available"
+else
+    print_fail "Python 3 not working"
+fi
+
+print_test "Testing pip packages..."
+if run_in_container python3 -c "import tqdm; import PIL; import magic" 2>&1; then
+    print_pass "Required Python packages installed"
+else
+    print_fail "Missing Python packages"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+print_header "TEST SUMMARY"
+
+TOTAL=$((PASSED + FAILED + SKIPPED))
+echo ""
+echo -e "Total tests: ${TOTAL}"
+echo -e "${GREEN}Passed: ${PASSED}${NC}"
+echo -e "${RED}Failed: ${FAILED}${NC}"
+echo -e "${YELLOW}Skipped: ${SKIPPED}${NC}"
+echo ""
+
+if [[ $FAILED -gt 0 ]]; then
+    echo -e "${RED}Some tests failed!${NC}"
+    exit 1
+else
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

This PR is a comprehensive modernization of the stego-toolkit for 2025 CTF usage. It updates the Docker image, adds modern steganography tools, improves scripts with better UX, and adds CI/CD.

### Key Changes

- **Modern Base Image**: Upgraded from Debian Stretch (2017) to Debian Bookworm (slim)
- **New Tools**: Added stegseek (lightning-fast steghide cracker), stegcracker, and hexyl
- **Improved Scripts**: All check/brute scripts now have `--help`, colored output, and better error handling
- **Security**: Non-root user by default, minimal image with `--no-install-recommends`
- **CI/CD**: GitHub Actions for automated builds and smoke tests
- **Python 3 Only**: Complete removal of Python 2 dependencies

### New Tools Added

| Tool | Description |
|------|-------------|
| [stegseek](https://github.com/RickdeJager/stegseek) | Cracks steghide files using rockyou.txt in under 2 seconds |
| [stegcracker](https://github.com/Paradoxis/StegCracker) | Steganography brute-force utility |
| [hexyl](https://github.com/sharkdp/hexyl) | Modern hex viewer with colored output |

### Breaking Changes

1. Container runs as non-root `stego` user by default (use `-u root` if needed)
2. Python 3 only - `pybrute.py` rewritten
3. Script arguments changed to use long options (`--help`, `--output`, etc.)

## Test Plan

- [ ] Build Docker image successfully
- [ ] Run `./tests/smoke_test.sh` to verify all tools are installed
- [ ] Test `check_jpg.sh --help` and `check_png.sh --help`
- [ ] Test `brute_jpg.sh` with stegseek on a sample file
- [ ] Verify CI workflow runs successfully on push

## How to Test

```bash
# Clone and checkout this branch
git clone https://github.com/consigcody94/stego-toolkit.git
cd stego-toolkit
git checkout modernization/2025-refresh

# Build the image
docker build -t stego-toolkit .

# Run smoke tests
./tests/smoke_test.sh stego-toolkit

# Test interactively
docker run -it --rm -v $(pwd)/data:/data stego-toolkit bash
```